### PR TITLE
refactor: simplified callback for can help check instead of events

### DIFF
--- a/client/laststand.lua
+++ b/client/laststand.lua
@@ -120,17 +120,8 @@ RegisterNetEvent('hospital:client:UseFirstAid', function()
     end
 end)
 
----@param helperId number playerId
-RegisterNetEvent('hospital:client:CanHelp', function(helperId)
-    if InLaststand then
-        if LaststandTime <= 300 then
-            TriggerServerEvent('hospital:server:CanHelp', helperId, true)
-        else
-            TriggerServerEvent('hospital:server:CanHelp', helperId, false)
-        end
-    else
-        TriggerServerEvent('hospital:server:CanHelp', helperId, false)
-    end
+lib.callback.register('hospital:client:canHelp', function()
+    return InLaststand and LaststandTime <= 300
 end)
 
 ---@param targetId number playerId

--- a/server/main.lua
+++ b/server/main.lua
@@ -226,20 +226,15 @@ RegisterNetEvent('hospital:server:UseFirstAid', function(targetId)
 	local src = source
 	local target = QBCore.Functions.GetPlayer(targetId)
 	if not target then return end
+	
+	lib.callback('hospital:client:canHelp', targetId, function(canHelp)
+		if not canHelp then
+			TriggerClientEvent('ox_lib:notify', src, { description = Lang:t('error.cant_help'), type = 'error' })
+			return
+		end
 
-	TriggerClientEvent('hospital:client:CanHelp', targetId, src)
-end)
-
----@param helperId number
----@param canHelp boolean
-RegisterNetEvent('hospital:server:CanHelp', function(helperId, canHelp)
-	local src = source
-	if not canHelp then
-		TriggerClientEvent('ox_lib:notify', src, { description = Lang:t('error.cant_help'), type = 'error' })
-		return
-	end
-
-	TriggerClientEvent('hospital:client:HelpPerson', helperId, src)
+		TriggerClientEvent('hospital:client:HelpPerson', src, targetId)
+	end)
 end)
 
 ---@param src number

--- a/server/main.lua
+++ b/server/main.lua
@@ -226,15 +226,14 @@ RegisterNetEvent('hospital:server:UseFirstAid', function(targetId)
 	local src = source
 	local target = QBCore.Functions.GetPlayer(targetId)
 	if not target then return end
-	
-	lib.callback('hospital:client:canHelp', targetId, function(canHelp)
-		if not canHelp then
-			TriggerClientEvent('ox_lib:notify', src, { description = Lang:t('error.cant_help'), type = 'error' })
-			return
-		end
 
-		TriggerClientEvent('hospital:client:HelpPerson', src, targetId)
-	end)
+	local canHelp = lib.callback.await('hospital:client:canHelp', targetId)
+	if not canHelp then
+		TriggerClientEvent('ox_lib:notify', src, { description = Lang:t('error.cant_help'), type = 'error' })
+		return
+	end
+
+	TriggerClientEvent('hospital:client:HelpPerson', src, targetId)
 end)
 
 ---@param src number


### PR DESCRIPTION
**Describe Pull request**
- simplified canHelp event on client and changed it to a callback

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [no] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
