### PR TITLE
refactor: tracking ems on duty with cache

### DIFF
--- a/client/hospital.lua
+++ b/client/hospital.lua
@@ -325,8 +325,3 @@ RegisterNetEvent('hospital:client:SendToBed', function(id, bed, isRevive)
         end
     end)
 end)
-
----@param amount integer
-RegisterNetEvent('hospital:client:SetDoctorCount', function(amount)
-    DoctorCount = amount
-end)

--- a/client/hospital.lua
+++ b/client/hospital.lua
@@ -2,7 +2,6 @@ local listen = false
 local bedObject = nil
 local bedOccupyingData = nil
 local cam = nil
-local doctorCount = 0
 
 ---checks if bed is available and within 500 distance of pos
 ---@param pos vector3 position close to bed
@@ -33,7 +32,7 @@ end
 
 ---Triggered on player checking into the hospital. Notifies doctors, and puts player in a hospital bed.
 RegisterNetEvent('qb-ambulancejob:checkin', function()
-    if doctorCount >= Config.MinimalDoctors then
+    if DoctorCount >= Config.MinimalDoctors then
         TriggerServerEvent("hospital:server:SendDoctorAlert")
         return
     end
@@ -163,7 +162,7 @@ else
     CreateThread(function()
         for _, v in pairs(Config.Locations.checking) do
             local function enterCheckInZone()
-                if doctorCount >= Config.MinimalDoctors then
+                if DoctorCount >= Config.MinimalDoctors then
                     lib.showTextUI(Lang:t('text.call_doc'))
                     CreateThread(function()
                         checkInControls("checkin")
@@ -329,5 +328,5 @@ end)
 
 ---@param amount integer
 RegisterNetEvent('hospital:client:SetDoctorCount', function(amount)
-    doctorCount = amount
+    DoctorCount = amount
 end)

--- a/client/job.lua
+++ b/client/job.lua
@@ -66,12 +66,6 @@ end
 ---@param jobInfo any player's job object
 RegisterNetEvent('QBCore:Client:OnJobUpdate', function(jobInfo)
     playerJob = jobInfo
-    if playerJob.name ~= 'ambulance' then return end
-    if playerJob.onduty then
-        TriggerServerEvent("hospital:server:AddDoctor")
-    else
-        TriggerServerEvent("hospital:server:RemoveDoctor")
-    end
 end)
 
 ---Initialize health and armor settings on the player's ped
@@ -111,26 +105,7 @@ RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
         playerJob = playerData.job
         initHealthAndArmor(ped, playerId, playerData.metadata)
         initDeathAndLastStand(playerData.metadata)
-        if playerJob.name ~= 'ambulance' or not playerJob.onduty then return end
-        TriggerServerEvent("hospital:server:AddDoctor")
     end)
-end)
-
----Update doctor count.
-RegisterNetEvent('QBCore:Client:OnPlayerUnload', function()
-    if playerJob.name ~= 'ambulance' or not playerJob.onduty then return end
-    TriggerServerEvent("hospital:server:RemoveDoctor")
-end)
-
----Updates doctor count when player goes on/off duty.
----@param onDuty boolean
-RegisterNetEvent('QBCore:Client:SetDuty', function(onDuty)
-    if playerJob.name ~= 'ambulance' or onDuty == playerJob.onduty then return end
-    if onDuty then
-        TriggerServerEvent("hospital:server:AddDoctor")
-    else
-        TriggerServerEvent("hospital:server:RemoveDoctor")
-    end
 end)
 
 ---show patient's treatment menu.

--- a/client/main.lua
+++ b/client/main.lua
@@ -27,6 +27,8 @@ LastStandAnim = "writhe_loop"
 IsEscorted = false
 OnPainKillers = false
 
+DoctorCount = 0
+
 ---@type number
 PlayerHealth = nil
 
@@ -392,3 +394,13 @@ function GetClosestPlayer()
     local coords = GetEntityCoords(cache.ped)
     return QBCore.Functions.GetClosestPlayer(coords)
 end
+
+---fetch and cache DoctorCount every minute from server.
+CreateThread(function()
+    while true do
+        QBCore.Functions.TriggerCallback('hospital:GetDoctors', function(medics)
+            DoctorCount = medics
+        end)
+        Wait(60000)
+    end
+end)

--- a/client/main.lua
+++ b/client/main.lua
@@ -398,9 +398,7 @@ end
 ---fetch and cache DoctorCount every minute from server.
 CreateThread(function()
     while true do
-        QBCore.Functions.TriggerCallback('hospital:GetDoctors', function(medics)
-            DoctorCount = medics
-        end)
+        DoctorCount = lib.callback.await('hospital:GetDoctors', false)
         Wait(60000)
     end
 end)

--- a/client/setdownedstate.lua
+++ b/client/setdownedstate.lua
@@ -1,5 +1,3 @@
-local isEmsOnDuty = false
-
 ---displays text on the player's screen.
 ---@param x number
 ---@param y number
@@ -26,7 +24,7 @@ local function drawTxt(x, y, width, height, scale, text, r, g, b, a)
 end
 
 local function displayRespawnText()
-    if DeathTime > 0 and isEmsOnDuty then
+    if DeathTime > 0 and DoctorCount > 0 then
         drawTxt(0.93, 1.44, 1.0, 1.0, 0.6, Lang:t('info.respawn_txt', { deathtime = math.ceil(DeathTime) }), 255, 255, 255, 255)
     else
         drawTxt(0.865, 1.44, 1.0, 1.0, 0.6, Lang:t('info.respawn_revive', { holdtime = RespawnHoldTime, cost = Config.BillCost }), 255, 255, 255, 255)
@@ -106,7 +104,7 @@ end
 
 ---Player is able to send a notification to EMS there are any on duty
 local function handleRequestingEms()
-    if not isEmsOnDuty then return end
+    if DoctorCount == 0 then return end
     if not EmsNotified then
         drawTxt(0.91, 1.40, 1.0, 1.0, 0.6, Lang:t('info.request_help'), 255, 255, 255, 255)
         if IsControlJustPressed(0, 47) then
@@ -159,15 +157,5 @@ CreateThread(function()
         else
             Wait(1000)
         end
-    end
-end)
-
----fetch and cache isEmsOnDuty boolean every minute from server.
-CreateThread(function()
-    while true do
-        QBCore.Functions.TriggerCallback('hospital:GetDoctors', function(medics)
-            isEmsOnDuty = medics > 0
-        end)
-        Wait(60000)
     end
 end)

--- a/server/main.lua
+++ b/server/main.lua
@@ -250,9 +250,7 @@ end)
 
 -- Callbacks
 
----@param _ any
----@param cb function
-QBCore.Functions.CreateCallback('hospital:GetDoctors', function(_, cb)
+lib.callback.register('hospital:GetDoctors', function()
 	local amount = 0
 	local players = QBCore.Functions.GetQBPlayers()
 	for _, v in pairs(players) do
@@ -260,7 +258,7 @@ QBCore.Functions.CreateCallback('hospital:GetDoctors', function(_, cb)
 			amount += 1
 		end
 	end
-	cb(amount)
+	return amount
 end)
 
 ---@param limbs BodyParts

--- a/server/main.lua
+++ b/server/main.lua
@@ -2,6 +2,8 @@ local QBCore = exports['qb-core']:GetCoreObject()
 
 ---@class Player object from core
 
+---@alias source number
+
 ---@class PlayerStatus
 ---@field limbs BodyParts
 ---@field isBleeding number
@@ -12,12 +14,8 @@ local playerStatus = {}
 ---@type table<source, number[]> weapon hashes
 local playerWeaponWounds = {}
 
-local doctorCount = 0
 local doctorCalled = false
 
----@alias source number
----@type table<source, boolean>
-local doctors = {}
 
 -- Events
 
@@ -166,29 +164,6 @@ RegisterNetEvent('hospital:server:TreatWounds', function(playerId)
 	player.Functions.RemoveItem('bandage', 1)
 	TriggerClientEvent('inventory:client:ItemBox', src, QBCore.Shared.Items['bandage'], "remove")
 	TriggerClientEvent("hospital:client:HealInjuries", patient.PlayerData.source, "full")
-end)
-
-RegisterNetEvent('hospital:server:AddDoctor', function()
-	local src = source
-	doctorCount += 1
-	TriggerClientEvent("hospital:client:SetDoctorCount", -1, doctorCount)
-	doctors[src] = true
-end)
-
-RegisterNetEvent('hospital:server:RemoveDoctor', function()
-	local src = source
-	doctorCount -= 1
-	TriggerClientEvent("hospital:client:SetDoctorCount", -1, doctorCount)
-	doctors[src] = nil
-end)
-
-AddEventHandler("playerDropped", function()
-	local src = source
-	if not doctors[src] then return end
-
-	doctorCount -= 1
-	TriggerClientEvent("hospital:client:SetDoctorCount", -1, doctorCount)
-	doctors[src] = nil
 end)
 
 ---@param playerId number
@@ -453,5 +428,3 @@ QBCore.Functions.CreateUseableItem("firstaid", function(source, item)
 	local src = source
 	triggerItemEventOnPlayer(src, item, 'hospital:client:UseFirstAid')
 end)
-
-exports('GetDoctorCount', function() return doctorCount end)


### PR DESCRIPTION
**Describe Pull request**
Removed keeping track of Ems on duty by incrementing and decrementing when Ems would come online, go offline, or toggle duty as this lead to many net events and verbose code and wasn't being used at all. Instead, we now calculate the number of Ems on duty from the server side and cache the value on each client. This value is only used to determine if Ems can be called for help while down or if check-in can be used in the hospital. The tradeoff is that this data will now become stale before being refreshed, but I don't believe that this should negatively affect gameplay much.

Future improvement ideas:
- cache the value on the server side as well so that it's not recalculated for each client
- on the client side, only request the number of Ems on demand with proper cache eviction controls rather than the simple while true loop that exists today.
- Probably lower the cache timeout once proper cache controls are in place. A minute might be too long, although should affect gameplay in 99.9% of cases. Just an edge case where an Ems just came on duty and someone can't check-in without waiting 1 minute first.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [no] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
