### PR TITLE
refactor(client): converted net events to event handlers which are client only

### DIFF
--- a/client/dead.lua
+++ b/client/dead.lua
@@ -27,6 +27,14 @@ function OnDeath()
     TriggerServerEvent('hospital:server:ambulanceAlert', Lang:t('info.civ_died'))
 end
 
+local function respawn()
+    TriggerServerEvent("hospital:server:RespawnAtHospital")
+    if exports["qb-policejob"]:IsHandcuffed() then
+        TriggerEvent("police:client:GetCuffed", -1)
+    end
+    TriggerEvent("police:client:DeEscort")
+end
+
 ---Allow player to respawn
 function AllowRespawn()
     RespawnHoldTime = 5
@@ -35,7 +43,7 @@ function AllowRespawn()
         DeathTime -= 1
         if DeathTime <= 0 then
             if IsControlPressed(0, 38) and RespawnHoldTime <= 1 and not IsInHospitalBed then
-                TriggerEvent("hospital:client:RespawnAtHospital")
+                respawn()
             end
             if IsControlPressed(0, 38) then
                 RespawnHoldTime -= 1

--- a/client/hospital.lua
+++ b/client/hospital.lua
@@ -32,7 +32,7 @@ local function getAvailableBed(bedId)
 end
 
 ---Triggered on player checking into the hospital. Notifies doctors, and puts player in a hospital bed.
-RegisterNetEvent('qb-ambulancejob:checkin', function()
+AddEventHandler('qb-ambulancejob:checkin', function()
     if doctorCount >= Config.MinimalDoctors then
         TriggerServerEvent("hospital:server:SendDoctorAlert")
         return
@@ -90,7 +90,7 @@ local function getClosestBed()
 end
 
 ---Puts player in the closest hospital bed if available.
-RegisterNetEvent('qb-ambulancejob:beds', function()
+AddEventHandler('qb-ambulancejob:beds', function()
     local closestBed = getClosestBed()
     if getAvailableBed(closestBed) then
         TriggerServerEvent("hospital:server:SendToBed", closestBed, false)

--- a/client/job.lua
+++ b/client/job.lua
@@ -30,7 +30,7 @@ end
 
 ---Configures and spawns an automobile and teleports player to the driver seat.
 ---@param vehicleName string name of vehicle to reference as config key
-RegisterNetEvent('ambulance:client:TakeOutVehicle', function(vehicleName)
+AddEventHandler('ambulance:client:TakeOutVehicle', function(vehicleName)
     local coords = Config.Locations.vehicle[currentGarage]
     QBCore.Functions.TriggerCallback('QBCore:Server:SpawnVehicle', function(netId)
         local veh = NetToVeh(netId)
@@ -296,14 +296,14 @@ local function emsControls(event)
 end
 
 ---Opens the hospital stash.
-RegisterNetEvent('qb-ambulancejob:stash', function()
+AddEventHandler('qb-ambulancejob:stash', function()
     if not playerJob.onduty then return end
     TriggerServerEvent("inventory:server:OpenInventory", "stash", "ambulancestash_" .. QBCore.Functions.GetPlayerData().citizenid)
     TriggerEvent("inventory:client:SetCurrentStash", "ambulancestash_" .. QBCore.Functions.GetPlayerData().citizenid)
 end)
 
 ---Opens the hospital armory.
-RegisterNetEvent('qb-ambulancejob:armory', function()
+AddEventHandler('qb-ambulancejob:armory', function()
     if playerJob.onduty then
         TriggerServerEvent("inventory:server:OpenInventory", "shop", "hospital", Config.Items)
     end
@@ -368,17 +368,17 @@ local function teleportPlayerWithFade(coords)
 end
 
 ---Teleports the player to main elevator
-RegisterNetEvent('qb-ambulancejob:elevator_roof', function()
+AddEventHandler('qb-ambulancejob:elevator_roof', function()
     teleportPlayerWithFade(Config.Locations.main[1])
 end)
 
 ---Teleports the player to roof elevator
-RegisterNetEvent('qb-ambulancejob:elevator_main', function()
+AddEventHandler('qb-ambulancejob:elevator_main', function()
     teleportPlayerWithFade(Config.Locations.roof[1])
 end)
 
 ---Toggles the on duty status of the player.
-RegisterNetEvent('EMSToggle:Duty', function()
+AddEventHandler('EMSToggle:Duty', function()
     playerJob.onduty = not playerJob.onduty
     TriggerServerEvent("QBCore:ToggleDuty")
     TriggerServerEvent("police:server:UpdateBlips")

--- a/client/main.lua
+++ b/client/main.lua
@@ -321,14 +321,6 @@ RegisterNetEvent('hospital:client:SetBed', function(bedsKey, id, isTaken)
     Config.Locations[bedsKey][id].taken = isTaken
 end)
 
-RegisterNetEvent('hospital:client:RespawnAtHospital', function()
-    TriggerServerEvent("hospital:server:RespawnAtHospital")
-    if exports["qb-policejob"]:IsHandcuffed() then
-        TriggerEvent("police:client:GetCuffed", -1)
-    end
-    TriggerEvent("police:client:DeEscort")
-end)
-
 ---sends player phone email with hospital bill.
 ---@param amount number
 RegisterNetEvent('hospital:client:SendBillEmail', function(amount)


### PR DESCRIPTION
**Describe Pull request**
- converted net event RespawnAtHospital to local function respawn() as it was only being called from one place
- converted net events which were only being triggered from client to event handlers since they don't need to be called over the network and we should prefer limited scope.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [no] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
