### PR TITLE
refactor: cacheing PlayerData

### DIFF
--- a/client/hospital.lua
+++ b/client/hospital.lua
@@ -234,10 +234,8 @@ local function leaveBed()
     bedOccupyingData = nil
     IsInHospitalBed = false
 
-    QBCore.Functions.GetPlayerData(function(PlayerData)
-        if PlayerData.metadata.injail <= 0 then return end
-        TriggerEvent("prison:client:Enter", PlayerData.metadata.injail)
-    end)
+    if PlayerData.metadata.injail <= 0 then return end
+    TriggerEvent("prison:client:Enter", PlayerData.metadata.injail)
 end
 
 ---Shows leave bed text if the player can leave the bed, triggers leaving the bed if the right key is pressed.

--- a/client/load-unload.lua
+++ b/client/load-unload.lua
@@ -1,0 +1,68 @@
+---Initialize health and armor settings on the player's ped
+---@param ped number
+---@param playerId number
+---@param playerMetadata any
+local function initHealthAndArmor(ped, playerId, playerMetadata)
+    SetEntityHealth(ped, playerMetadata.health)
+    SetPlayerHealthRechargeMultiplier(playerId, 0.0)
+    SetPlayerHealthRechargeLimit(playerId, 0.0)
+    SetPedArmour(ped, playerMetadata.armor)
+end
+
+---starts death or last stand based off of player's metadata
+---@param metadata any
+local function initDeathAndLastStand(metadata)
+    if not metadata.inlaststand and metadata.isdead then
+        DeathTime = Laststand.ReviveInterval
+        OnDeath()
+        AllowRespawn()
+    elseif metadata.inlaststand and not metadata.isdead then
+        StartLastStand()
+    else
+        TriggerServerEvent("hospital:server:SetDeathStatus", false)
+        TriggerServerEvent("hospital:server:SetLaststandStatus", false)
+    end
+end
+
+---initialize settings from player object
+local function onPlayerLoaded()
+    exports.spawnmanager:setAutoSpawn(false)
+    CreateThread(function()
+        Wait(1000)
+        local ped = cache.ped
+        local playerId = cache.playerId
+        PlayerData = QBCore.Functions.GetPlayerData()
+        initHealthAndArmor(ped, playerId, PlayerData.metadata)
+        initDeathAndLastStand(PlayerData.metadata)
+    end)
+end
+
+---reset player settings that the server is storing
+local function onPlayerUnloaded()
+    local ped = cache.ped
+    TriggerServerEvent("hospital:server:SetDeathStatus", false)
+    TriggerServerEvent('hospital:server:SetLaststandStatus', false)
+    TriggerServerEvent("hospital:server:SetArmor", GetPedArmour(ped))
+    if BedOccupying then
+        TriggerServerEvent("hospital:server:LeaveBed", BedOccupying)
+    end
+    IsDead = false
+    DeathTime = 0
+    SetEntityInvincible(ped, false)
+    SetPedArmour(ped, 0)
+    ResetAllInjuries()
+end
+
+RegisterNetEvent('QBCore:Client:OnPlayerLoaded', onPlayerLoaded)
+
+RegisterNetEvent('QBCore:Client:OnPlayerUnload', onPlayerUnloaded)
+
+AddEventHandler('onResourceStart', function(resourceName)
+    if GetCurrentResourceName() ~= resourceName then return end
+    onPlayerLoaded()
+end)
+
+AddEventHandler('onResourceStop', function(resourceName)
+    if GetCurrentResourceName() ~= resourceName then return end
+    onPlayerUnloaded()
+end)

--- a/client/main.lua
+++ b/client/main.lua
@@ -72,6 +72,7 @@ BodyParts = {
 }
 
 RegisterNetEvent('QBCore:Player:SetPlayerData', function(data)
+    if GetInvokingResource() then return end
     PlayerData = data
 end)
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -26,8 +26,10 @@ LastStandDict = "combat@damage@writhe"
 LastStandAnim = "writhe_loop"
 IsEscorted = false
 OnPainKillers = false
-
 DoctorCount = 0
+PlayerData = {
+    job = nil
+}
 
 ---@type number
 PlayerHealth = nil
@@ -68,6 +70,10 @@ BodyParts = {
     ['RLEG'] = { label = Lang:t('body.right_leg'), causeLimp = true, isDamaged = false, severity = 0 },
     ['RFOOT'] = { label = Lang:t('body.right_foot'), causeLimp = true, isDamaged = false, severity = 0 },
 }
+
+RegisterNetEvent('QBCore:Player:SetPlayerData', function(data)
+    PlayerData = data
+end)
 
 ---notify the player of damage to their body.
 local function doLimbAlert()
@@ -158,7 +164,7 @@ function ResetMajorInjuries()
     })
 end
 
-local function resetAllInjuries()
+function ResetAllInjuries()
     IsBleeding = 0
     BleedTickTimer = 0
     AdvanceBleedTimer = 0
@@ -274,7 +280,7 @@ RegisterNetEvent('hospital:client:Revive', function()
     SetEntityHealth(ped, 200)
     ClearPedBloodDamage(ped)
     SetPlayerSprint(cache.playerId, true)
-    resetAllInjuries()
+    ResetAllInjuries()
     ResetPedMovementClipset(ped, 0.0)
     TriggerServerEvent('hud:server:RelieveStress', 100)
     TriggerServerEvent("hospital:server:SetDeathStatus", false)
@@ -307,7 +313,7 @@ end)
 ---@param type? "full"|any heals all wounds if full otherwise heals only major wounds.
 RegisterNetEvent('hospital:client:HealInjuries', function(type)
     if type == "full" then
-        resetAllInjuries()
+        ResetAllInjuries()
     else
         ResetMajorInjuries()
     end
@@ -327,12 +333,12 @@ end)
 ---@param amount number
 RegisterNetEvent('hospital:client:SendBillEmail', function(amount)
     SetTimeout(math.random(2500, 4000), function()
-        local gender = QBCore.Functions.GetPlayerData().charinfo.gender == 1 and Lang:t('info.mrs') or Lang:t('info.mr')
-        local charinfo = QBCore.Functions.GetPlayerData().charinfo
+        local charInfo = PlayerData.charinfo
+        local gender = charInfo.gender == 1 and Lang:t('info.mrs') or Lang:t('info.mr')
         TriggerServerEvent('qb-phone:server:sendNewMail', {
             sender = Lang:t('mail.sender'),
             subject = Lang:t('mail.subject'),
-            message = Lang:t('mail.message', { gender = gender, lastname = charinfo.lastname, costs = amount }),
+            message = Lang:t('mail.message', { gender = gender, lastname = charInfo.lastname, costs = amount }),
             button = {}
         })
     end)
@@ -341,22 +347,6 @@ end)
 RegisterNetEvent('hospital:client:adminHeal', function()
     SetEntityHealth(cache.ped, 200)
     TriggerServerEvent("hospital:server:resetHungerThirst")
-end)
-
----sync settings to server when player logs out.
-RegisterNetEvent('QBCore:Client:OnPlayerUnload', function()
-    local ped = cache.ped
-    TriggerServerEvent("hospital:server:SetDeathStatus", false)
-    TriggerServerEvent('hospital:server:SetLaststandStatus', false)
-    TriggerServerEvent("hospital:server:SetArmor", GetPedArmour(ped))
-    if BedOccupying then
-        TriggerServerEvent("hospital:server:LeaveBed", BedOccupying)
-    end
-    IsDead = false
-    DeathTime = 0
-    SetEntityInvincible(ped, false)
-    SetPedArmour(ped, 0)
-    resetAllInjuries()
 end)
 
 -- Threads

--- a/client/wounding.lua
+++ b/client/wounding.lua
@@ -198,7 +198,7 @@ local function applyBleedEffects(ped)
     local randX = math.random() + math.random(-1, 1)
     local randY = math.random() + math.random(-1, 1)
     local coords = GetOffsetFromEntityInWorldCoords(ped, randX, randY, 0)
-    TriggerServerEvent("evidence:server:CreateBloodDrop", QBCore.Functions.GetPlayerData().citizenid, QBCore.Functions.GetPlayerData().metadata.bloodtype, coords)
+    TriggerServerEvent("evidence:server:CreateBloodDrop", PlayerData.citizenid, PlayerData.metadata.bloodtype, coords)
 
     if AdvanceBleedTimer >= Config.AdvanceBleedTimer then
         ApplyBleed(1)


### PR DESCRIPTION
**Describe Pull request**
- instead of calling QBCore.Functions.GetPlayerData, using the QBCore:Player:SetPlayerData event to listen for changes in PlayerData and cache in a variable.
- Moved player load/unload events into new file
- Added experimental feature resource start/stop event handlers that do the same thing as player load/unload. I'm not  sure yet that this is going to work to reload the resource but hoping it's a start.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [no] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
