### PR TITLE
refactor!: limiting scope of net events

### DIFF
--- a/client/hospital.lua
+++ b/client/hospital.lua
@@ -311,6 +311,7 @@ end
 ---@param bed Bed
 ---@param isRevive boolean if true, heals the player
 RegisterNetEvent('hospital:client:SendToBed', function(id, bed, isRevive)
+    if GetInvokingResource() then return end
     BedOccupying = id
     bedOccupyingData = bed
     setBedCam()

--- a/client/job.lua
+++ b/client/job.lua
@@ -76,7 +76,7 @@ local function initDeathAndLastStand(metadata)
 end
 
 ---initialize settings from player object
-RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
+AddEventHandler('QBCore:Client:OnPlayerLoaded', function()
     exports.spawnmanager:setAutoSpawn(false)
     CreateThread(function()
         Wait(1000)
@@ -120,6 +120,7 @@ local function getPatientStatus(damagedBodyParts)
 end
 
 ---Check status of nearest player and show treatment menu.
+---Intended to be invoked by client or server.
 RegisterNetEvent('hospital:client:CheckStatus', function()
     local player, distance = GetClosestPlayer()
     if player == -1 or distance > 5.0 then
@@ -157,6 +158,7 @@ RegisterNetEvent('hospital:client:CheckStatus', function()
 end)
 
 ---Use first aid on nearest player to revive them.
+---Intended to be invoked by client or server.
 RegisterNetEvent('hospital:client:RevivePlayer', function()
     if not QBCore.Functions.HasItem('firstaid') then
         lib.notify({ description = Lang:t('error.no_firstaid'), type = 'error' })
@@ -197,6 +199,7 @@ RegisterNetEvent('hospital:client:RevivePlayer', function()
 end)
 
 ---Use bandage on nearest player to treat their wounds.
+---Intended to be invoked by client or server.
 RegisterNetEvent('hospital:client:TreatWounds', function()
     if not QBCore.Functions.HasItem('bandage') then
         lib.notify({ description = Lang:t('error.no_bandage'), type = 'error' })

--- a/client/laststand.lua
+++ b/client/laststand.lua
@@ -95,15 +95,15 @@ function EndLastStand()
     TriggerServerEvent("hospital:server:SetLaststandStatus", false)
 end
 
--- Events
-
 ---@param bool boolean
-RegisterNetEvent('hospital:client:SetEscortingState', function(bool)
+---TODO: this event name should be changed within qb-policejob to be generic
+AddEventHandler('hospital:client:SetEscortingState', function(bool)
     isEscorting = bool
 end)
 
 ---@param bool boolean
-RegisterNetEvent('hospital:client:isEscorted', function(bool)
+---TODO: this event name should be changed within qb-policejob to be generic
+AddEventHandler('hospital:client:isEscorted', function(bool)
     IsEscorted = bool
 end)
 
@@ -127,6 +127,7 @@ end)
 
 ---@param targetId number playerId
 RegisterNetEvent('hospital:client:HelpPerson', function(targetId)
+    if GetInvokingResource() then return end
     local ped = cache.ped
     if lib.progressCircle({
         duration = math.random(30000, 60000),

--- a/client/main.lua
+++ b/client/main.lua
@@ -213,6 +213,7 @@ end
 ---@param coords vector3
 ---@param text string
 RegisterNetEvent('hospital:client:ambulanceAlert', function(coords, text)
+    if GetInvokingResource() then return end
     local street1, street2 = GetStreetNameAtCoord(coords.x, coords.y, coords.z)
     local street1name = GetStreetNameFromHashKey(street1)
     local street2name = GetStreetNameFromHashKey(street2)
@@ -251,6 +252,7 @@ RegisterNetEvent('hospital:client:ambulanceAlert', function(coords, text)
 end)
 
 ---Revives player, healing all injuries
+---Intended to be called from client or server.
 RegisterNetEvent('hospital:client:Revive', function()
     local ped = cache.ped
 
@@ -285,6 +287,7 @@ end)
 
 ---Creates random injuries on the player
 RegisterNetEvent('hospital:client:SetPain', function()
+    if GetInvokingResource() then return end
     ApplyBleed(math.random(1, 4))
     local bone = Config.Bones[24816]
 
@@ -300,12 +303,14 @@ RegisterNetEvent('hospital:client:SetPain', function()
 end)
 
 RegisterNetEvent('hospital:client:KillPlayer', function()
+    if GetInvokingResource() then return end
     SetEntityHealth(cache.ped, 0)
 end)
 
 ---heals player wounds.
 ---@param type? "full"|any heals all wounds if full otherwise heals only major wounds.
 RegisterNetEvent('hospital:client:HealInjuries', function(type)
+    if GetInvokingResource() then return end
     if type == "full" then
         resetAllInjuries()
     else
@@ -320,12 +325,14 @@ end)
 ---@param id number
 ---@param isTaken boolean
 RegisterNetEvent('hospital:client:SetBed', function(bedsKey, id, isTaken)
+    if GetInvokingResource() then return end
     Config.Locations[bedsKey][id].taken = isTaken
 end)
 
 ---sends player phone email with hospital bill.
 ---@param amount number
 RegisterNetEvent('hospital:client:SendBillEmail', function(amount)
+    if GetInvokingResource() then return end
     SetTimeout(math.random(2500, 4000), function()
         local gender = QBCore.Functions.GetPlayerData().charinfo.gender == 1 and Lang:t('info.mrs') or Lang:t('info.mr')
         local charinfo = QBCore.Functions.GetPlayerData().charinfo
@@ -339,6 +346,7 @@ RegisterNetEvent('hospital:client:SendBillEmail', function(amount)
 end)
 
 RegisterNetEvent('hospital:client:adminHeal', function()
+    if GetInvokingResource() then return end
     SetEntityHealth(cache.ped, 200)
     TriggerServerEvent("hospital:server:resetHungerThirst")
 end)

--- a/server/main.lua
+++ b/server/main.lua
@@ -74,6 +74,7 @@ local function respawnAtHospital(player, bedsKey)
 end
 
 RegisterNetEvent('hospital:server:RespawnAtHospital', function()
+	if GetInvokingResource() then return end
 	local player = QBCore.Functions.GetPlayer(source)
 	if player.PlayerData.metadata.injail > 0 then
 		respawnAtHospital(player, "jailbeds")
@@ -85,6 +86,7 @@ end)
 ---@param bedId integer
 ---@param isRevive boolean
 RegisterNetEvent('hospital:server:SendToBed', function(bedId, isRevive)
+	if GetInvokingResource() then return end
 	local src = source
 	local player = QBCore.Functions.GetPlayer(src)
 	TriggerClientEvent('hospital:client:SendToBed', src, bedId, Config.Locations.beds[bedId], isRevive)
@@ -94,6 +96,7 @@ end)
 
 ---@param text string
 RegisterNetEvent('hospital:server:ambulanceAlert', function(text)
+	if GetInvokingResource() then return end
 	local src = source
 	local ped = GetPlayerPed(src)
 	local coords = GetEntityCoords(ped)
@@ -107,17 +110,20 @@ end)
 
 ---@param id integer
 RegisterNetEvent('hospital:server:LeaveBed', function(id)
+	if GetInvokingResource() then return end
 	TriggerClientEvent('hospital:client:SetBed', -1, "beds", id, false)
 end)
 
 ---@param data Injury
 RegisterNetEvent('hospital:server:SyncInjuries', function(data)
+	if GetInvokingResource() then return end
 	local src = source
 	playerStatus[src] = data
 end)
 
 ---@param data number[] weapon hashes
 RegisterNetEvent('hospital:server:SetWeaponDamage', function(data)
+	if GetInvokingResource() then return end
 	local src = source
 	local player = QBCore.Functions.GetPlayer(src)
 	if not player then return end
@@ -125,6 +131,7 @@ RegisterNetEvent('hospital:server:SetWeaponDamage', function(data)
 end)
 
 RegisterNetEvent('hospital:server:RestoreWeaponDamage', function()
+	if GetInvokingResource() then return end
 	local src = source
 	local player = QBCore.Functions.GetPlayer(src)
 	playerWeaponWounds[player.PlayerData.source] = nil
@@ -132,6 +139,7 @@ end)
 
 ---@param isDead boolean
 RegisterNetEvent('hospital:server:SetDeathStatus', function(isDead)
+	if GetInvokingResource() then return end
 	local src = source
 	local player = QBCore.Functions.GetPlayer(src)
 	if not player then return end
@@ -140,6 +148,7 @@ end)
 
 ---@param bool boolean
 RegisterNetEvent('hospital:server:SetLaststandStatus', function(bool)
+	if GetInvokingResource() then return end
 	local src = source
 	local player = QBCore.Functions.GetPlayer(src)
 	if not player then return end
@@ -148,6 +157,7 @@ end)
 
 ---@param amount number
 RegisterNetEvent('hospital:server:SetArmor', function(amount)
+	if GetInvokingResource() then return end
 	local src = source
 	local player = QBCore.Functions.GetPlayer(src)
 	if not player then return end
@@ -156,6 +166,7 @@ end)
 
 ---@param playerId number
 RegisterNetEvent('hospital:server:TreatWounds', function(playerId)
+	if GetInvokingResource() then return end
 	local src = source
 	local player = QBCore.Functions.GetPlayer(src)
 	local patient = QBCore.Functions.GetPlayer(playerId)
@@ -168,6 +179,7 @@ end)
 
 ---@param playerId number
 RegisterNetEvent('hospital:server:RevivePlayer', function(playerId)
+	if GetInvokingResource() then return end
 	local player = QBCore.Functions.GetPlayer(source)
 	local patient = QBCore.Functions.GetPlayer(playerId)
 
@@ -178,6 +190,7 @@ RegisterNetEvent('hospital:server:RevivePlayer', function(playerId)
 end)
 
 RegisterNetEvent('hospital:server:SendDoctorAlert', function()
+	if GetInvokingResource() then return end
 	local src = source
 	if doctorCalled then
 		TriggerClientEvent('ox_lib:notify', src, { description = Lang:t('info.dr_needed'), type = 'inform' })
@@ -198,6 +211,7 @@ end)
 
 ---@param targetId number
 RegisterNetEvent('hospital:server:UseFirstAid', function(targetId)
+	if GetInvokingResource() then return end
 	local src = source
 	local target = QBCore.Functions.GetPlayer(targetId)
 	if not target then return end
@@ -212,6 +226,7 @@ RegisterNetEvent('hospital:server:UseFirstAid', function(targetId)
 end)
 
 RegisterNetEvent('hospital:server:resetHungerThirst', function()
+	if GetInvokingResource() then return end
 	local player = QBCore.Functions.GetPlayer(source)
 
 	if not player then return end


### PR DESCRIPTION
**Describe Pull request**
- for each net event, verified that it wasn't being triggered from its own side of the network within Qbox, then restricted scope so that it can't be called from its own side of the network. If I found it was being called on its own side of the network, I left a comment stating as such.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [no] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
