### PR TITLE
refactor(client): injury migration to qbx-medical

### DIFF
--- a/client/damage/damage-effects.lua
+++ b/client/damage/damage-effects.lua
@@ -95,7 +95,7 @@ end
 ---@param ped number
 function ApplyDamageEffects(ped)
     if IsDead or InLaststand then return end
-    for _, injury in pairs(Injured) do
+    for _, injury in pairs(exports['qbx-medical']:getInjuries()) do
         if isLegDamaged(injury) then
             if legCount >= Config.LegInjuryTimer then
                 chancePedFalls(ped)

--- a/client/damage/damage.lua
+++ b/client/damage/damage.lua
@@ -99,32 +99,6 @@ local function applyImmediateEffects(ped, bone, weapon, damageDone)
     end
 end
 
----Increases severity of an injury
----@param bodyPart BodyPart
----@param bone Bone
-local function upgradeInjury(bodyPart, bone)
-    if bodyPart.severity >= 4 then return end
-
-    bodyPart.severity += 1
-    exports['qbx-medical']:damageBodyPart(bone, bodyPart.severity)
-    for _, injury in pairs(Injured) do
-        if injury.part == bone then
-            injury.severity = bodyPart.severity
-        end
-    end
-end
-
----create/upgrade injury at bone.
----@param bone Bone
-local function injureBodyPart(bone)
-    local bodyPart = exports['qbx-medical']:getBodyPartsDeprecated()[bone]
-    if not bodyPart.isDamaged then
-        CreateInjury(bodyPart, bone, 3)
-    else
-        upgradeInjury(bodyPart, bone)
-    end
-end
-
 ---Apply bleeds, injure the body part hit, make ped limp/stagger
 ---@param ped number
 ---@param boneId integer
@@ -137,7 +111,7 @@ local function checkDamage(ped, boneId, weapon, damageDone)
     if not bone or IsDead or InLaststand then return end
 
     applyImmediateEffects(ped, bone, weapon, damageDone)
-    injureBodyPart(bone)
+    exports['qbx-medical']:injureBodyPart(bone)
 
     TriggerServerEvent('hospital:server:SyncInjuries', {
         limbs = exports['qbx-medical']:getBodyPartsDeprecated(),

--- a/client/wounding.lua
+++ b/client/wounding.lua
@@ -140,29 +140,6 @@ CreateThread(function()
     end
 end)
 
-local function getWorstInjury()
-    local level = 0
-    for _, injury in pairs(Injured) do
-        if injury.severity > level then
-            level = injury.severity
-        end
-    end
-
-    return level
-end
-
-CreateThread(function()
-    while true do
-        if #Injured > 0 then
-            local level = getWorstInjury()
-            SetPedMoveRateOverride(cache.ped, Config.MovementRate[level])
-            Wait(5)
-        else
-            Wait(1000)
-        end
-    end
-end)
-
 ---@param ped number
 local function makePlayerBlackout(ped)
     SetFlash(0, 0, 100, 7000, 100)

--- a/config.lua
+++ b/config.lua
@@ -281,13 +281,6 @@ Config.BleedingStates = { -- Translate bleeding alerts
     [4] = { label = Lang:t('states.big_bleed') },
 }
 
-Config.MovementRate = { -- Set the player movement rate based on the level of damage they have
-    0.98,
-    0.96,
-    0.94,
-    0.92,
-}
-
 Config.Bones = { -- Correspond bone hash numbers to their label
     [0]     = 'NONE',
     [31085] = 'HEAD',


### PR DESCRIPTION
## Description

- remove Injuries variable and related code to move to qbx-medical
- Replace references to Injured with exports from qbx-medical

## Checklist

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
