### PR TITLE
Fix Export ResetAllInjuries()

### DIFF
--- a/client/load-unload.lua
+++ b/client/load-unload.lua
@@ -50,7 +50,7 @@ local function onPlayerUnloaded()
     exports['qbx-medical']:setDeathTime(0)
     SetEntityInvincible(ped, false)
     SetPedArmour(ped, 0)
-    exports['qbx-medical']:resetAllInjuries()
+    exports['qbx-medical']:ResetAllInjuries()
 end
 
 AddEventHandler('QBCore:Client:OnPlayerLoaded', onPlayerLoaded)


### PR DESCRIPTION
## Description

Client side error is thrown that the export doesn't exist. The "r" is capitalized within qbx-medical which is why this export doesn't work

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
