### PR TITLE
refactor: bed overhaul

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -76,14 +76,6 @@ RegisterNetEvent('hospital:client:Revive', function()
     EmsNotified = false
 end)
 
----@param bedsKey "jailbeds"|"beds"
----@param id number
----@param isTaken boolean
-RegisterNetEvent('hospital:client:SetBed', function(bedsKey, id, isTaken)
-    if GetInvokingResource() then return end
-    Config.Locations[bedsKey][id].taken = isTaken
-end)
-
 ---sends player phone email with hospital bill.
 ---@param amount number
 RegisterNetEvent('hospital:client:SendBillEmail', function(amount)

--- a/config.lua
+++ b/config.lua
@@ -9,10 +9,6 @@ Config.AIHealTimer = 20 -- How long it will take to be healed after checking in,
 Config.LaststandMinimumRevive = 300
 
 Config.Locations = { -- Edit the various interaction points for players or create new ones
-    checking = {
-        [1] = vec3(308.19, -595.35, 43.29),
-        [2] = vec3(-254.54, 6331.78, 32.43),
-    },
     duty = {
         [1] = vec3(311.18, -599.25, 43.29),
         [2] = vec3(-254.88, 6324.5, 32.58),
@@ -38,32 +34,47 @@ Config.Locations = { -- Edit the various interaction points for players or creat
     stash = {
         [1] = vec3(309.78, -596.6, 43.29),
     },
+
     ---@class Bed
     ---@field coords vector4
-    ---@field taken boolean
     ---@field model number
 
-    ---@type Bed[]
-    beds = {
-        [1] = { coords = vec4(353.1, -584.6, 43.11, 152.08), taken = false, model = 1631638868 },
-        [2] = { coords = vec4(356.79, -585.86, 43.11, 152.08), taken = false, model = 1631638868 },
-        [3] = { coords = vec4(354.12, -593.12, 43.1, 336.32), taken = false, model = 2117668672 },
-        [4] = { coords = vec4(350.79, -591.8, 43.1, 336.32), taken = false, model = 2117668672 },
-        [5] = { coords = vec4(346.99, -590.48, 43.1, 336.32), taken = false, model = 2117668672 },
-        [6] = { coords = vec4(360.32, -587.19, 43.02, 152.08), taken = false, model = -1091386327 },
-        [7] = { coords = vec4(349.82, -583.33, 43.02, 152.08), taken = false, model = -1091386327 },
-        [8] = { coords = vec4(326.98, -576.17, 43.02, 152.08), taken = false, model = -1091386327 },
-        --- paleto
-        [9] = { coords = vec4(-252.43, 6312.25, 32.34, 313.48), taken = false, model = 2117668672 },
-        [10] = { coords = vec4(-247.04, 6317.95, 32.34, 134.64), taken = false, model = 2117668672 },
-        [11] = { coords = vec4(-255.98, 6315.67, 32.34, 313.91), taken = false, model = 2117668672 },
+    ---@type table<string, {coords: vector3, checkIn?: vector3, beds: Bed[]}>
+    hospitals = {
+        pillbox = {
+            coords = vec3(350, -580, 43),
+            checkIn = vec3(308.19, -595.35, 43.29),
+            beds = {
+                { coords = vec4(353.1, -584.6, 43.11, 152.08), model = 1631638868 },
+                { coords = vec4(356.79, -585.86, 43.11, 152.08), model = 1631638868 },
+                { coords = vec4(354.12, -593.12, 43.1, 336.32), model = 2117668672 },
+                { coords = vec4(350.79, -591.8, 43.1, 336.32), model = 2117668672 },
+                { coords = vec4(346.99, -590.48, 43.1, 336.32), model = 2117668672 },
+                { coords = vec4(360.32, -587.19, 43.02, 152.08), model = -1091386327 },
+                { coords = vec4(349.82, -583.33, 43.02, 152.08), model = -1091386327 },
+                { coords = vec4(326.98, -576.17, 43.02, 152.08), model = -1091386327 },
+            }
+        },
+        paleto = {
+            coords = vec3(-250, 6315, 32),
+            checkIn = vec3(-254.54, 6331.78, 32.43),
+            beds = {
+                { coords = vec4(-252.43, 6312.25, 32.34, 313.48), model = 2117668672 },
+                { coords = vec4(-247.04, 6317.95, 32.34, 134.64), model = 2117668672 },
+                { coords = vec4(-255.98, 6315.67, 32.34, 313.91), model = 2117668672 },
+            }
+        },
+        jail = {
+            coords = vec3(1761, 2600, 46),
+            beds = {
+                { coords = vec4(1761.96, 2597.74, 45.66, 270.14), model = 2117668672 },
+                { coords = vec4(1761.96, 2591.51, 45.66, 269.8), model = 2117668672 },
+                { coords = vec4(1771.8, 2598.02, 45.66, 89.05), model = 2117668672 },
+                { coords = vec4(1771.85, 2591.85, 45.66, 91.51), model = 2117668672 },
+            }
+        }
     },
-    jailbeds = {
-        [1] = { coords = vec4(1761.96, 2597.74, 45.66, 270.14), taken = false, model = 2117668672 },
-        [2] = { coords = vec4(1761.96, 2591.51, 45.66, 269.8), taken = false, model = 2117668672 },
-        [3] = { coords = vec4(1771.8, 2598.02, 45.66, 89.05), taken = false, model = 2117668672 },
-        [4] = { coords = vec4(1771.85, 2591.85, 45.66, 91.51), taken = false, model = 2117668672 },
-    },
+
     stations = {
         [1] = { label = Lang:t('info.pb_hospital'), coords = vec4(304.27, -600.33, 43.28, 272.249) }
     }

--- a/server/main.lua
+++ b/server/main.lua
@@ -50,9 +50,11 @@ local function respawn(src)
 		local closest = nil
 
 		for hospitalName, hospital in pairs(Config.Locations.hospitals) do
-			if not closest or #(coords - hospital.coords) < closest then
-				closest = hospital.coords
-				closestHospital = hospitalName
+			if hospitalName ~= 'jail' then
+				if not closest or #(coords - hospital.coords) < closest then
+					closest = hospital.coords
+					closestHospital = hospitalName
+				end
 			end
 		end
 	end


### PR DESCRIPTION
## Description

- re-organized beds and check-in under a hospital object to organize a bed as uniquely identified by a hospital + bedIndex. This is more precise than checking for distance to nearest bed, as players are now guaranteed to get into the bed selected, even if they are closer to another bed. This also has the added benefit of reducing most of the distance calculations and makes things like respawning prisoners in the jail beds easier.
- removed taken boolean from config so that config is static
- added taken tracking to server side. Server is now the authority on which beds are taken, no more syncing this data to the client
- Consolidated functions that did similar work regarding beds to streamline code paths
- used inside() function of ox_lib zones for key press listening instead of having our own loop
- Re-did all bed related events to be written in cause and effect form and removed unneeded ones

## Checklist

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
