### PR TITLE
fix(server/main): source being sent instead of hospitalName

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -36,7 +36,7 @@ local function getOpenBed(hospitalName)
 	end
 end
 
-lib.callback.register('qbx-ambulancejob:server:getOpenBed', function(source, hospitalName)
+lib.callback.register('qbx-ambulancejob:server:getOpenBed', function(_, hospitalName)
 	return getOpenBed(hospitalName)
 end)
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -36,7 +36,7 @@ local function getOpenBed(hospitalName)
 	end
 end
 
-lib.callback.register('qbx-ambulancejob:server:getOpenBed', function(hospitalName)
+lib.callback.register('qbx-ambulancejob:server:getOpenBed', function(source, hospitalName)
 	return getOpenBed(hospitalName)
 end)
 


### PR DESCRIPTION
## Description

Fixes [script:qbx-ambulance] SCRIPT ERROR: @qbx-ambulancejob/server/main.lua:35: attempt to get length of a nil value (local 'beds')

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
