### PR TITLE
bugfixes, revert notify

### DIFF
--- a/client/hospital.lua
+++ b/client/hospital.lua
@@ -50,7 +50,7 @@ local function putPlayerInBed(hospitalName, bedIndex, isRevive, skipOpenCheck)
     if IsInHospitalBed then return end
     if not skipOpenCheck then
         if lib.callback.await('qbx-ambulancejob:server:isBedTaken', false, hospitalName, bedIndex) then
-            lib.notify({ description = Lang:t('error.beds_taken'), type = 'error' })
+            QBCore.Functions.Notify(Lang:t('error.beds_taken'), 'error')
             return
         end
     end
@@ -65,7 +65,7 @@ local function putPlayerInBed(hospitalName, bedIndex, isRevive, skipOpenCheck)
     CreateThread(function()
         Wait(5)
         if isRevive then
-            lib.notify({ description = Lang:t('success.being_helped'), type = 'success' })
+            QBCore.Functions.Notify(Lang:t('success.being_helped'), 'success')
             Wait(Config.AIHealTimer * 1000)
             TriggerEvent("hospital:client:Revive")
         else
@@ -92,14 +92,10 @@ local function checkIn(hospitalName)
         useWhileDead = false,
         canCancel = true,
         disable = {
-            move = false,
-            car = false,
+            move = true,
+            car = true,
             combat = true,
             mouse = false,
-        },
-        anim = {
-            dict = HealAnimDict,
-            clip = HealAnim,
         },
     })
     then
@@ -107,14 +103,14 @@ local function checkIn(hospitalName)
         --- ask server for first non taken bed
         local bedIndex = lib.callback.await('qbx-ambulancejob:server:getOpenBed', false, hospitalName)
         if not bedIndex then
-            lib.notify({ description = Lang:t('error.beds_taken'), type = 'error' })
+            QBCore.Functions.Notify(Lang:t('error.beds_taken'), 'error')
             return
         end
 
         putPlayerInBed(hospitalName, bedIndex, true, true)
     else
         exports.scully_emotemenu:cancelEmote()
-        lib.notify({ description = Lang:t('error.canceled'), type = 'error' })
+        QBCore.Functions.Notify(Lang:t('error.canceled'), 'error')
     end
 end
 

--- a/client/job.lua
+++ b/client/job.lua
@@ -73,7 +73,7 @@ end
 RegisterNetEvent('hospital:client:CheckStatus', function()
     local player, distance = GetClosestPlayer()
     if player == -1 or distance > 5.0 then
-        lib.notify({ description = Lang:t('error.no_player'), type = 'error' })
+        QBCore.Functions.Notify(Lang:t('error.no_player'), 'error')
         return
     end
     local playerId = GetPlayerServerId(player)
@@ -81,7 +81,7 @@ RegisterNetEvent('hospital:client:CheckStatus', function()
     ---@param damage PlayerDamage
     local damage = lib.callback.await('hospital:GetPlayerStatus', false, playerId)
     if not damage or (damage.bleedLevel == 0 and #damage.damagedBodyParts == 0 and #damage.weaponWounds == 0) then
-        lib.notify({ description = Lang:t('success.healthy_player'), type = 'success' })
+        QBCore.Functions.Notify(Lang:t('success.healthy_player'), 'success')
         return
     end
 
@@ -109,13 +109,13 @@ end)
 ---Intended to be invoked by client or server.
 RegisterNetEvent('hospital:client:RevivePlayer', function()
     if not QBCore.Functions.HasItem('firstaid') then
-        lib.notify({ description = Lang:t('error.no_firstaid'), type = 'error' })
+        QBCore.Functions.Notify(Lang:t('error.no_firstaid'), 'error')
         return
     end
 
     local player, distance = GetClosestPlayer()
     if player == -1 or distance >= 5.0 then
-        lib.notify({ description = Lang:t('error.no_player'), type = 'error' })
+        QBCore.Functions.Notify(Lang:t('error.no_player'), 'error')
         return
     end
 
@@ -138,11 +138,11 @@ RegisterNetEvent('hospital:client:RevivePlayer', function()
     })
     then
         StopAnimTask(cache.ped, HealAnimDict, "exit", 1.0)
-        lib.notify({ description = Lang:t('success.revived'), type = 'success' })
+        QBCore.Functions.Notify(Lang:t('success.revived'), 'success')
         TriggerServerEvent("hospital:server:RevivePlayer", GetPlayerServerId(player))
     else
         StopAnimTask(cache.ped, HealAnimDict, "exit", 1.0)
-        lib.notify({ description = Lang:t('error.canceled'), type = 'error' })
+        QBCore.Functions.Notify(Lang:t('error.canceled'), 'error')
     end
 end)
 
@@ -150,13 +150,13 @@ end)
 ---Intended to be invoked by client or server.
 RegisterNetEvent('hospital:client:TreatWounds', function()
     if not QBCore.Functions.HasItem('bandage') then
-        lib.notify({ description = Lang:t('error.no_bandage'), type = 'error' })
+        QBCore.Functions.Notify(Lang:t('error.no_bandage'), 'error')
         return
     end
 
     local player, distance = GetClosestPlayer()
     if player == -1 or distance >= 5.0 then
-        lib.notify({ description = Lang:t('error.no_player'), type = 'error' })
+        QBCore.Functions.Notify(Lang:t('error.no_player'), 'error')
         return
     end
 
@@ -179,11 +179,11 @@ RegisterNetEvent('hospital:client:TreatWounds', function()
     })
     then
         StopAnimTask(cache.ped, HealAnimDict, "exit", 1.0)
-        lib.notify({ description = Lang:t('success.helped_player'), type = 'success' })
+        QBCore.Functions.Notify(Lang:t('success.helped_player'), 'success')
         TriggerServerEvent("hospital:server:TreatWounds", GetPlayerServerId(player))
     else
         StopAnimTask(cache.ped, HealAnimDict, "exit", 1.0)
-        lib.notify({ description = Lang:t('error.canceled'), type = 'error' })
+        QBCore.Functions.Notify(Lang:t('error.canceled'), 'error')
     end
 end)
 

--- a/client/laststand.lua
+++ b/client/laststand.lua
@@ -9,7 +9,7 @@ end)
 ---use first aid pack on nearest player.
 lib.callback.register('hospital:client:UseFirstAid', function()
     if isEscorting then
-        lib.notify({ description = Lang:t('error.impossible'), type = 'error' })
+        QBCore.Functions.Notify(Lang:t('error.impossible'), 'error')
         return
     end
         
@@ -47,10 +47,10 @@ RegisterNetEvent('hospital:client:HelpPerson', function(targetId)
     })
     then
         ClearPedTasks(ped)
-        lib.notify({ description = Lang:t('success.revived'), type = 'success' })
+        QBCore.Functions.Notify(Lang:t('success.revived'), 'success')
         TriggerServerEvent("hospital:server:RevivePlayer", targetId)
     else
         ClearPedTasks(ped)
-        lib.notify({ description = Lang:t('error.canceled'), type = 'error' })
+        QBCore.Functions.Notify(Lang:t('error.canceled'), 'error')
     end
 end)

--- a/client/main.lua
+++ b/client/main.lua
@@ -27,7 +27,7 @@ RegisterNetEvent('hospital:client:ambulanceAlert', function(coords, text)
     local street1, street2 = GetStreetNameAtCoord(coords.x, coords.y, coords.z)
     local street1name = GetStreetNameFromHashKey(street1)
     local street2name = GetStreetNameFromHashKey(street2)
-    lib.notify({ title = Lang:t('text.alert'), description = text .. ' | ' .. street1name .. ' ' .. street2name, type = 'inform' })
+    QBCore.Functions.Notify({ title = Lang:t('text.alert'), description = text .. ' | ' .. street1name .. ' ' .. street2name, type = 'inform' })
     PlaySound(-1, "Lose_1st", "GTAO_FM_Events_Soundset", 0, 0, 1)
     local transG = 250
     local blip = AddBlipForCoord(coords.x, coords.y, coords.z)

--- a/client/setdownedstate.lua
+++ b/client/setdownedstate.lua
@@ -54,7 +54,7 @@ local function handleLastStand()
     if laststandTime > Config.LaststandMinimumRevive then
         DrawText2D(Lang:t('info.bleed_out', { time = math.ceil(laststandTime) }), vec2(0.94, 1.44), 1.0, 1.0, 0.6, 4, 255, 255, 255, 255)
     else
-        DrawText2D(Lang:t('info.bleed_out_help', { time = math.ceil(laststandTime) }), vec2(0.845, 1.44), 1.0, 1.0, 0.6, 4, 255, 255, 255, 255)
+        DrawText2D(Lang:t('info.bleed_out_help', { time = math.ceil(laststandTime) }), vec2(0.94, 1.44), 1.0, 1.0, 0.6, 4, 255, 255, 255, 255)
         handleRequestingEms()
     end
 

--- a/client/wounding.lua
+++ b/client/wounding.lua
@@ -36,7 +36,7 @@ lib.callback.register('hospital:client:UseIfaks', function()
         return true
     else
         StopAnimTask(ped, "mp_suicide", "pill", 1.0)
-        lib.notify({ description = Lang:t('error.canceled'), type = 'error' })
+        QBCore.Functions.Notify(Lang:t('error.canceled'), 'error')
         return false
     end
 end)
@@ -73,7 +73,7 @@ lib.callback.register('hospital:client:UseBandage', function()
         return true
     else
         StopAnimTask(ped, "anim@amb@business@weed@weed_inspecting_high_dry@", "weed_inspecting_high_base_inspector", 1.0)
-        lib.notify({ description = Lang:t('error.canceled'), type = 'error' })
+        QBCore.Functions.Notify(Lang:t('error.canceled'), 'error')
         return false
     end
 end)
@@ -107,7 +107,7 @@ lib.callback.register('hospital:client:UsePainkillers', function()
         return true
     else
         StopAnimTask(ped, "mp_suicide", "pill", 1.0)
-        lib.notify({ description = Lang:t('error.canceled'), type = 'error' })
+        QBCore.Functions.Notify(Lang:t('error.canceled'), 'error')
         return false
     end
 end)

--- a/config.lua
+++ b/config.lua
@@ -10,29 +10,28 @@ Config.LaststandMinimumRevive = 300
 
 Config.Locations = { -- Edit the various interaction points for players or create new ones
     duty = {
-        vec3(311.18, -599.25, 43.29),
-        vec3(-254.88, 6324.5, 32.58),
+        [1] = vec3(311.18, -599.25, 43.29),
+        [2] = vec3(-254.88, 6324.5, 32.58),
     },
     vehicle = {
-        vec4(294.578, -574.761, 43.179, 35.79),
-        vec4(-234.28, 6329.16, 32.15, 222.5),
+        [1] = vec4(294.578, -574.761, 43.179, 35.79),
+        [2] = vec4(-234.28, 6329.16, 32.15, 222.5),
     },
     helicopter = {
-        vec4(351.58, -587.45, 74.16, 160.5),
-        vec4(-475.43, 5988.353, 31.716, 31.34),
+        [1] = vec4(351.58, -587.45, 74.16, 160.5),
+        [2] = vec4(-475.43, 5988.353, 31.716, 31.34),
     },
-    armory = {
-        vec3(309.93, -602.94, 43.29),
-        vec3(-245.13, 6315.71, 32.82),
+    armory = { -- Currently not in use, use ox_inventory/data/shops.lua instead
+        --[1] = vec3(0.0, 0.0, 0.0),
     },
     roof = {
-        vec3(338.54, -583.88, 74.17),
+        [1] = vec3(338.54, -583.88, 74.17),
     },
     main = {
-        vec3(298.62, -599.66, 43.29),
+        [1] = vec3(298.62, -599.66, 43.29),
     },
-    stash = {
-        vec3(309.78, -596.6, 43.29),
+    stash = { -- Currently not in use, use ox_inventory/data/stashes.lua instead
+        --[1] = vec3(0.0, 0.0, 0.0),
     },
 
     ---@class Bed
@@ -94,7 +93,6 @@ Config.AuthorizedVehicles = { -- Vehicles players can use based on their ambulan
     -- Grade 1
     [1] = {
         ["ambulance"] = "Ambulance",
-
     },
     -- Grade 2
     [2] = {
@@ -119,7 +117,6 @@ Config.AuthorizedHelicopters = {
     -- Grade 1
     [1] = {
         ["polmav"] = "Helicopter",
-
     },
     -- Grade 2
     [2] = {
@@ -267,7 +264,7 @@ Config.BoneIndexes = { -- Correspond bone labels to their hash number
 }
 
 Config.VehicleSettings = { -- Enable or disable vehicle extras when pulling them from the ambulance job vehicle spawner
-    ["car1"] = { -- Model name
+    ["ambulance"] = { -- Model name
         extras = {
             ["1"] = false, -- on/off
             ["2"] = true,

--- a/config.lua
+++ b/config.lua
@@ -10,28 +10,28 @@ Config.LaststandMinimumRevive = 300
 
 Config.Locations = { -- Edit the various interaction points for players or create new ones
     duty = {
-        [1] = vec3(311.18, -599.25, 43.29),
-        [2] = vec3(-254.88, 6324.5, 32.58),
+        vec3(311.18, -599.25, 43.29),
+        vec3(-254.88, 6324.5, 32.58),
     },
     vehicle = {
-        [1] = vec4(294.578, -574.761, 43.179, 35.79),
-        [2] = vec4(-234.28, 6329.16, 32.15, 222.5),
+        vec4(294.578, -574.761, 43.179, 35.79),
+        vec4(-234.28, 6329.16, 32.15, 222.5),
     },
     helicopter = {
-        [1] = vec4(351.58, -587.45, 74.16, 160.5),
-        [2] = vec4(-475.43, 5988.353, 31.716, 31.34),
+        vec4(351.58, -587.45, 74.16, 160.5),
+        vec4(-475.43, 5988.353, 31.716, 31.34),
     },
     armory = { -- Currently not in use, use ox_inventory/data/shops.lua instead
-        --[1] = vec3(0.0, 0.0, 0.0),
+        --vec3(0.0, 0.0, 0.0),
     },
     roof = {
-        [1] = vec3(338.54, -583.88, 74.17),
+        vec3(338.54, -583.88, 74.17),
     },
     main = {
-        [1] = vec3(298.62, -599.66, 43.29),
+        vec3(298.62, -599.66, 43.29),
     },
     stash = { -- Currently not in use, use ox_inventory/data/stashes.lua instead
-        --[1] = vec3(0.0, 0.0, 0.0),
+        --vec3(0.0, 0.0, 0.0),
     },
 
     ---@class Bed

--- a/locales/es.lua
+++ b/locales/es.lua
@@ -89,12 +89,14 @@ local Translations = {
         heli_button = '[E] - Sacar / guardar helicoptero',
         elevator_roof = '[E] - Tomar el elevador al último piso',
         elevator_main = '[E] - Tomar el elevador hacía abajo',
+        el_roof = 'Tomar el elevador al último piso',
         bed_out = '[E] - Para salir de la cama..',
         call_doc = '[E] - Llamar doctor',
         call = 'Llamar',
         check_in = '[E] Hacer check-in',
         check = 'Check-in',
-        lie_bed = '[E] - Para acostarse en la cama'
+        lie_bed = '[E] - Para acostarse en la cama',
+        bed = 'Acostarse en la cama',
     },
     body = {
         head = 'cabeza',

--- a/server/main.lua
+++ b/server/main.lua
@@ -51,8 +51,7 @@ local function respawn(src)
 
 		for hospitalName, hospital in pairs(Config.Locations.hospitals) do
 			if hospitalName ~= 'jail' then
-				local distance = #(coords - hospital.coords)
-				if not closest or distance < #(coords - closest) then
+				if not closest or #(coords - hospital.coords) < #(coords - closest) then
 					closest = hospital.coords
 					closestHospital = hospitalName
 				end

--- a/server/main.lua
+++ b/server/main.lua
@@ -36,7 +36,7 @@ local function getOpenBed(hospitalName)
 	end
 end
 
-lib.callback.register('qbx-ambulancejob:server:getOpenBed', function(hospitalName)
+lib.callback.register('qbx-ambulancejob:server:getOpenBed', function(_, hospitalName)
 	return getOpenBed(hospitalName)
 end)
 
@@ -51,7 +51,8 @@ local function respawn(src)
 
 		for hospitalName, hospital in pairs(Config.Locations.hospitals) do
 			if hospitalName ~= 'jail' then
-				if not closest or #(coords - hospital.coords) < closest then
+				local distance = #(coords - hospital.coords)
+				if not closest or distance < #(coords - closest) then
 					closest = hospital.coords
 					closestHospital = hospitalName
 				end


### PR DESCRIPTION
## Description

- Removed the animation from ox_target on check-in so that scully emote animation is used (already in code)
- Fixed the respawn not working after dead when holding E for several seconds
- Revert notifies

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
