### PR TITLE
fix(setdownedstate): text flickering and text shown

### DIFF
--- a/client/setdownedstate.lua
+++ b/client/setdownedstate.lua
@@ -6,7 +6,7 @@ end
 
 local function displayRespawnText()
     local deathTime = exports['qbx-medical']:getDeathTime()
-    if deathTime > 0 and getDoctorCount() > 0 then
+    if deathTime > 0 and doctorCount > 0 then
         DrawText2D(Lang:t('info.respawn_txt', { deathtime = math.ceil(deathTime) }), vec2(1.0, 1.44), 1.0, 1.0, 0.6, 4, 255, 255, 255, 255)
     else
         DrawText2D(Lang:t('info.respawn_revive', { holdtime = exports['qbx-medical']:getRespawnHoldTimeDeprecated(), cost = Config.BillCost }), vec2(1.0, 1.44), 1.0, 1.0, 0.6, 4, 255, 255, 255, 255)

--- a/client/setdownedstate.lua
+++ b/client/setdownedstate.lua
@@ -9,6 +9,8 @@ local function displayRespawnText()
     local deathTime = exports['qbx-medical']:getDeathTime()
     if deathTime > 0 and getDoctorCount() > 0 then
         DrawText2D(Lang:t('info.respawn_txt', { deathtime = math.ceil(deathTime) }), vec2(1.0, 1.44), 1.0, 1.0, 0.6, 4, 255, 255, 255, 255)
+    elseif doctorCount == 0 then
+        DrawText2D(Lang:t('info.bleed_out', { time = math.ceil(laststandTime) }), vec2(1.0, 1.44), 1.0, 1.0, 0.6, 4, 255, 255, 255, 255)
     else
         DrawText2D(Lang:t('info.respawn_revive', { holdtime = exports['qbx-medical']:getRespawnHoldTimeDeprecated(), cost = Config.BillCost }), vec2(1.0, 1.44), 1.0, 1.0, 0.6, 4, 255, 255, 255, 255)
     end

--- a/client/setdownedstate.lua
+++ b/client/setdownedstate.lua
@@ -9,8 +9,6 @@ local function displayRespawnText()
     local deathTime = exports['qbx-medical']:getDeathTime()
     if deathTime > 0 and getDoctorCount() > 0 then
         DrawText2D(Lang:t('info.respawn_txt', { deathtime = math.ceil(deathTime) }), vec2(1.0, 1.44), 1.0, 1.0, 0.6, 4, 255, 255, 255, 255)
-    elseif doctorCount == 0 then
-        DrawText2D(Lang:t('info.bleed_out', { time = math.ceil(laststandTime) }), vec2(1.0, 1.44), 1.0, 1.0, 0.6, 4, 255, 255, 255, 255)
     else
         DrawText2D(Lang:t('info.respawn_revive', { holdtime = exports['qbx-medical']:getRespawnHoldTimeDeprecated(), cost = Config.BillCost }), vec2(1.0, 1.44), 1.0, 1.0, 0.6, 4, 255, 255, 255, 255)
     end
@@ -38,7 +36,7 @@ local function handleDead(ped)
     SetCurrentPedWeapon(ped, `WEAPON_UNARMED`, true)
 end
 
----Player is able to send a notification to EMS there are any on duty
+---Player is able to send a notification to EMS there are any on dutyeeeeeeeeee
 local function handleRequestingEms()
     if not EmsNotified then
         DrawText2D(Lang:t('info.request_help'), vec2(1.0, 1.40), 1.0, 1.0, 0.6, 4, 255, 255, 255, 255)
@@ -54,6 +52,8 @@ end
 local function handleLastStand()
     local laststandTime = exports['qbx-medical']:getLaststandTime()
     if laststandTime > Config.LaststandMinimumRevive or doctorCount == 0 then
+        DrawText2D(Lang:t('info.bleed_out', { time = math.ceil(laststandTime) }), vec2(1.0, 1.44), 1.0, 1.0, 0.6, 4, 255, 255, 255, 255)
+    elseif doctorCount == 0 then
         DrawText2D(Lang:t('info.bleed_out', { time = math.ceil(laststandTime) }), vec2(1.0, 1.44), 1.0, 1.0, 0.6, 4, 255, 255, 255, 255)
     else
         DrawText2D(Lang:t('info.bleed_out_help', { time = math.ceil(laststandTime) }), vec2(1.0, 1.44), 1.0, 1.0, 0.6, 4, 255, 255, 255, 255)

--- a/client/setdownedstate.lua
+++ b/client/setdownedstate.lua
@@ -1,8 +1,7 @@
 local doctorCount = 0
 
 local function getDoctorCount()
-    doctorCount = lib.callback.await('hospital:GetDoctors')
-    return doctorCount
+    return lib.callback.await('hospital:GetDoctors')
 end
 
 local function displayRespawnText()

--- a/client/setdownedstate.lua
+++ b/client/setdownedstate.lua
@@ -50,7 +50,7 @@ end
 
 local function handleLastStand()
     local laststandTime = exports['qbx-medical']:getLaststandTime()
-    if laststandTime > Config.LaststandMinimumRevive or doctorCount == 0 then
+    if laststandTime > Config.LaststandMinimumRevive then
         DrawText2D(Lang:t('info.bleed_out', { time = math.ceil(laststandTime) }), vec2(1.0, 1.44), 1.0, 1.0, 0.6, 4, 255, 255, 255, 255)
     elseif doctorCount == 0 then
         DrawText2D(Lang:t('info.bleed_out', { time = math.ceil(laststandTime) }), vec2(1.0, 1.44), 1.0, 1.0, 0.6, 4, 255, 255, 255, 255)

--- a/client/setdownedstate.lua
+++ b/client/setdownedstate.lua
@@ -38,7 +38,6 @@ end
 
 ---Player is able to send a notification to EMS there are any on duty
 local function handleRequestingEms()
-    --if getDoctorCount() == 0 then return end
     if not EmsNotified then
         DrawText2D(Lang:t('info.request_help'), vec2(1.0, 1.40), 1.0, 1.0, 0.6, 4, 255, 255, 255, 255)
         if IsControlJustPressed(0, 47) then

--- a/client/setdownedstate.lua
+++ b/client/setdownedstate.lua
@@ -1,15 +1,16 @@
+local doctorCount = 0
+
 local function getDoctorCount()
-    return cache('doctorCount', function()
-        lib.callback.await('hospital:GetDoctors')
-    end, 60000)
+    doctorCount = lib.callback.await('hospital:GetDoctors')
+    return doctorCount
 end
 
 local function displayRespawnText()
     local deathTime = exports['qbx-medical']:getDeathTime()
     if deathTime > 0 and getDoctorCount() > 0 then
-        DrawText2D(Lang:t('info.respawn_txt', { deathtime = math.ceil(deathTime) }), vec2(0.93, 1.44), 1.0, 1.0, 0.6, 4, 255, 255, 255, 255)
+        DrawText2D(Lang:t('info.respawn_txt', { deathtime = math.ceil(deathTime) }), vec2(1.0, 1.44), 1.0, 1.0, 0.6, 4, 255, 255, 255, 255)
     else
-        DrawText2D(Lang:t('info.respawn_revive', { holdtime = exports['qbx-medical']:getRespawnHoldTimeDeprecated(), cost = Config.BillCost }), vec2(0.865, 1.44), 1.0, 1.0, 0.6, 4, 255, 255, 255, 255)
+        DrawText2D(Lang:t('info.respawn_revive', { holdtime = exports['qbx-medical']:getRespawnHoldTimeDeprecated(), cost = Config.BillCost }), vec2(1.0, 1.44), 1.0, 1.0, 0.6, 4, 255, 255, 255, 255)
     end
 end
 
@@ -37,24 +38,26 @@ end
 
 ---Player is able to send a notification to EMS there are any on duty
 local function handleRequestingEms()
-    if getDoctorCount() == 0 then return end
+    --if getDoctorCount() == 0 then return end
     if not EmsNotified then
-        DrawText2D(Lang:t('info.request_help'), vec2(0.91, 1.40), 1.0, 1.0, 0.6, 4, 255, 255, 255, 255)
+        DrawText2D(Lang:t('info.request_help'), vec2(1.0, 1.40), 1.0, 1.0, 0.6, 4, 255, 255, 255, 255)
         if IsControlJustPressed(0, 47) then
             TriggerServerEvent('hospital:server:ambulanceAlert', Lang:t('info.civ_down'))
             EmsNotified = true
         end
     else
-        DrawText2D(Lang:t('info.help_requested'), vec2(0.90, 1.40), 1.0, 1.0, 0.6, 4, 255, 255, 255, 255)
+        DrawText2D(Lang:t('info.help_requested'), vec2(1.0, 1.40), 1.0, 1.0, 0.6, 4, 255, 255, 255, 255)
     end
 end
 
 local function handleLastStand()
     local laststandTime = exports['qbx-medical']:getLaststandTime()
     if laststandTime > Config.LaststandMinimumRevive then
-        DrawText2D(Lang:t('info.bleed_out', { time = math.ceil(laststandTime) }), vec2(0.94, 1.44), 1.0, 1.0, 0.6, 4, 255, 255, 255, 255)
+        DrawText2D(Lang:t('info.bleed_out', { time = math.ceil(laststandTime) }), vec2(1.0, 1.44), 1.0, 1.0, 0.6, 4, 255, 255, 255, 255)
+    elseif doctorCount == 0 then
+        DrawText2D(Lang:t('info.bleed_out', { time = math.ceil(laststandTime) }), vec2(1.0, 1.44), 1.0, 1.0, 0.6, 4, 255, 255, 255, 255)
     else
-        DrawText2D(Lang:t('info.bleed_out_help', { time = math.ceil(laststandTime) }), vec2(0.94, 1.44), 1.0, 1.0, 0.6, 4, 255, 255, 255, 255)
+        DrawText2D(Lang:t('info.bleed_out_help', { time = math.ceil(laststandTime) }), vec2(1.0, 1.44), 1.0, 1.0, 0.6, 4, 255, 255, 255, 255)
         handleRequestingEms()
     end
 
@@ -92,5 +95,12 @@ CreateThread(function()
         else
             Wait(1000)
         end
+    end
+end)
+
+CreateThread(function()
+    while true do
+        doctorCount = getDoctorCount()
+        Wait(60000)
     end
 end)

--- a/client/setdownedstate.lua
+++ b/client/setdownedstate.lua
@@ -36,7 +36,7 @@ local function handleDead(ped)
     SetCurrentPedWeapon(ped, `WEAPON_UNARMED`, true)
 end
 
----Player is able to send a notification to EMS there are any on dutyeeeeeeeeee
+---Player is able to send a notification to EMS there are any on duty
 local function handleRequestingEms()
     if not EmsNotified then
         DrawText2D(Lang:t('info.request_help'), vec2(1.0, 1.40), 1.0, 1.0, 0.6, 4, 255, 255, 255, 255)

--- a/client/setdownedstate.lua
+++ b/client/setdownedstate.lua
@@ -51,9 +51,7 @@ end
 
 local function handleLastStand()
     local laststandTime = exports['qbx-medical']:getLaststandTime()
-    if laststandTime > Config.LaststandMinimumRevive then
-        DrawText2D(Lang:t('info.bleed_out', { time = math.ceil(laststandTime) }), vec2(1.0, 1.44), 1.0, 1.0, 0.6, 4, 255, 255, 255, 255)
-    elseif doctorCount == 0 then
+    if laststandTime > Config.LaststandMinimumRevive or doctorCount == 0 then
         DrawText2D(Lang:t('info.bleed_out', { time = math.ceil(laststandTime) }), vec2(1.0, 1.44), 1.0, 1.0, 0.6, 4, 255, 255, 255, 255)
     else
         DrawText2D(Lang:t('info.bleed_out_help', { time = math.ceil(laststandTime) }), vec2(1.0, 1.44), 1.0, 1.0, 0.6, 4, 255, 255, 255, 255)


### PR DESCRIPTION
## Description

This is an attempt to fix https://github.com/Qbox-project/qbx-ambulancejob/issues/82. I created one more thread, checked performance and did not seem to be an issue, not sure with a large server, there are probably more efficient ways, but this way we can avoid text flickering when calling the function directly.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
