### PR TITLE
refactor: enable debugPoly via config

### DIFF
--- a/client/hospital.lua
+++ b/client/hospital.lua
@@ -127,7 +127,7 @@ if config.useTarget then
                     coords = hospital.checkIn,
                     size = vec3(2, 1, 2),
                     rotation = 18,
-                    debug = false,
+                    debug = config.debugPoly,
                     options = {
                         {
                             onSelect = function()
@@ -148,7 +148,7 @@ if config.useTarget then
                     coords = bed.coords.xyz,
                     size = vec3(1.7, 1.9, 2),
                     rotation = bed.coords.w,
-                    debug = false,
+                    debug = config.debugPoly,
                     options = {
                         {
                             onSelect = function()
@@ -192,7 +192,7 @@ else
                     coords = hospital.checkIn,
                     size = vec3(2, 1, 2),
                     rotation = 18,
-                    debug = false,
+                    debug = config.debugPoly,
                     onEnter = enterCheckInZone,
                     onExit = outCheckInZone,
                     inside = insideCheckInZone,
@@ -222,7 +222,7 @@ else
                     coords = bed.coords.xyz,
                     size = vec3(1.9, 2.1, 2),
                     rotation = bed.coords.w,
-                    debug = false,
+                    debug = config.debugPoly,
                     onEnter = enterBedZone,
                     onExit = outBedZone,
                     inside = insideBedZone,

--- a/client/job.lua
+++ b/client/job.lua
@@ -287,7 +287,7 @@ local function createGarage(vehicles, vehiclePlatePrefix, coords)
         coords = coords.xyz,
         size = vec3(5, 5, 2),
         rotation = coords.w,
-        debug = false,
+        debug = config.debugPoly,
         inside = inVehicleZone,
         onExit = outVehicleZone
     })

--- a/client/job.lua
+++ b/client/job.lua
@@ -313,7 +313,7 @@ if config.useTarget then
                 coords = sharedConfig.locations.duty[i],
                 size = vec3(1.5, 1, 2),
                 rotation = 71,
-                debug = false,
+                debug = config.debugPoly,
                 options = {
                     {
                         type = "client",
@@ -332,7 +332,7 @@ if config.useTarget then
                 coords = sharedConfig.locations.stash[i],
                 size = vec3(1, 1, 2),
                 rotation = -20,
-                debug = false,
+                debug = config.debugPoly,
                 options = {
                     {
                         type = "client",
@@ -351,7 +351,7 @@ if config.useTarget then
                 coords = sharedConfig.locations.armory[i],
                 size = vec3(1, 1, 2),
                 rotation = -20,
-                debug = false,
+                debug = config.debugPoly,
                 options = {
                     {
                         type = "client",
@@ -369,12 +369,12 @@ if config.useTarget then
             coords = sharedConfig.locations.roof[1],
             size = vec3(1, 2, 2),
             rotation = -20,
-            debug = false,
+            debug = config.debugPoly,
             options = {
                 {
                     type = "client",
                     onSelect = teleportToMainElevator,
-                    icon = "fas fa-hand-point-up",
+                    icon = "fas fa-hand-point-down",
                     label = Lang:t('text.el_main'),
                     distance = 1.5,
                     groups = "ambulance",
@@ -386,7 +386,7 @@ if config.useTarget then
             coords = sharedConfig.locations.main[1],
             size = vec3(2, 1, 2),
             rotation = -20,
-            debug = false,
+            debug = config.debugPoly,
             options = {
                 {
                     type = "client",
@@ -422,7 +422,7 @@ else
                 coords = sharedConfig.locations.duty[i],
                 size = vec3(1, 1, 2),
                 rotation = -20,
-                debug = false,
+                debug = config.debugPoly,
                 onEnter = enteredSignInZone,
                 onExit = outSignInZone,
                 inside = insideDutyZone,
@@ -448,7 +448,7 @@ else
                 coords = sharedConfig.locations.stash[i],
                 size = vec3(1, 1, 2),
                 rotation = -20,
-                debug = false,
+                debug = config.debugPoly,
                 onEnter = enteredStashZone,
                 onExit = outStashZone,
                 inside = insideStashZone,
@@ -474,7 +474,7 @@ else
                 coords = sharedConfig.locations.armory[i],
                 size = vec3(1, 1, 2),
                 rotation = -20,
-                debug = false,
+                debug = config.debugPoly,
                 onEnter = enteredArmoryZone,
                 onExit = outArmoryZone,
                 inside = insideArmoryZone,
@@ -501,7 +501,7 @@ else
             coords = sharedConfig.locations.roof[1],
             size = vec3(1, 1, 2),
             rotation = -20,
-            debug = false,
+            debug = config.debugPoly,
             onEnter = enteredRoofZone,
             onExit = outRoofZone,
             inside = insideRoofZone,
@@ -527,7 +527,7 @@ else
             coords = sharedConfig.locations.main[1],
             size = vec3(1, 1, 2),
             rotation = -20,
-            debug = false,
+            debug = config.debugPoly,
             onEnter = enteredMainZone,
             onExit = outMainZone,
             inside = insideMainZone,

--- a/config/client.lua
+++ b/config/client.lua
@@ -1,5 +1,6 @@
 return {
     useTarget = false,
+    debugPoly = false,
     minForCheckIn = 2, -- Minimum number of people with the ambulance job to prevent the check-in system from being used
     painkillerInterval = 60, -- Time in minutes that painkillers last for
     checkInHealTime = 20, -- Time in seconds that it takes to be healed from the check-in system

--- a/config/server.lua
+++ b/config/server.lua
@@ -1,4 +1,4 @@
 return {
     doctorCallCooldown = 1, -- Time in minutes for cooldown between doctors calls
-    wipeInvOnRespawn = true, -- Enable ro disable removing all items from player on respawn
+    wipeInvOnRespawn = true, -- Enable to disable removing all items from player on respawn
 }


### PR DESCRIPTION
## Description

Add debugPoly option to config to enable folks to see all the poly zones vice turning on debugs individually.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [X] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X] My code fits the style guidelines.
- [X] My PR fits the contribution guidelines.
