### PR TITLE
bugfix: ems heals work and adjust healing

### DIFF
--- a/client/hospital.lua
+++ b/client/hospital.lua
@@ -64,14 +64,15 @@ local function putPlayerInBed(hospitalName, bedIndex, isRevive, skipOpenCheck)
     exports.qbx_medical:DisableDamageEffects()
     exports.qbx_medical:disableRespawn()
     CanLeaveBed = false
+    local numDoctors = lib.callback.await('qbx_ambulancejob:server:getNumDoctors')
     setBedCam()
     CreateThread(function()
         Wait(5)
         if isRevive then
             exports.qbx_core:Notify(Lang:t('success.being_helped'), 'success')
             Wait(config.aiHealTimer * 1000)
-            TriggerEvent("hospital:client:Revive")
-        else
+            TriggerEvent("qbx_medical:client:playerRevived")
+        elseif numDoctors == 0 then
             CanLeaveBed = true
         end
     end)
@@ -273,6 +274,10 @@ CreateThread(function()
             lib.hideTextUI()
         else
             Wait(1000)
+            local numDoctors = lib.callback.await('qbx_ambulancejob:server:getNumDoctors')
+            if numDoctors == 0 or (not exports.qbx_medical:isDead() and not exports.qbx_medical:getLaststand()) then
+                CanLeaveBed = true
+            end
         end
     end
 end)

--- a/client/job.lua
+++ b/client/job.lua
@@ -114,7 +114,7 @@ end)
 ---Use first aid on nearest player to revive them.
 ---Intended to be invoked by client or server.
 RegisterNetEvent('hospital:client:RevivePlayer', function()
-    if not exports.qbx_core:HasItem('firstaid') then
+    if exports.ox_inventory:Search('count', 'firstaid') == 0 then
         exports.qbx_core:Notify(Lang:t('error.no_firstaid'), 'error')
         return
     end
@@ -155,7 +155,7 @@ end)
 ---Use bandage on nearest player to treat their wounds.
 ---Intended to be invoked by client or server.
 RegisterNetEvent('hospital:client:TreatWounds', function()
-    if not exports.qbx_core:HasItem('bandage') then
+    if exports.ox_inventory:Search('count', 'bandage') == 0 then
         exports.qbx_core:Notify(Lang:t('error.no_bandage'), 'error')
         return
     end

--- a/client/wounding.lua
+++ b/client/wounding.lua
@@ -24,9 +24,8 @@ lib.callback.register('hospital:client:UseIfaks', function()
     })
     then
         StopAnimTask(ped, "mp_suicide", "pill", 1.0)
-        TriggerEvent("inventory:client:ItemBox", exports.ox_inventory:Items()["ifaks"], "remove")
         TriggerServerEvent('hud:server:RelieveStress', math.random(12, 24))
-        SetEntityHealth(ped, GetEntityHealth(ped) + 10)
+        SetEntityHealth(ped, GetEntityHealth(ped) + 50)
         OnPainKillers = true
         exports.qbx_medical:DisableDamageEffects()
         if painkillerAmount < 3 then
@@ -64,8 +63,7 @@ lib.callback.register('hospital:client:UseBandage', function()
     })
     then
         StopAnimTask(ped, "anim@amb@business@weed@weed_inspecting_high_dry@", "weed_inspecting_high_base_inspector", 1.0)
-        TriggerEvent("inventory:client:ItemBox", exports.ox_inventory:Items()["bandage"], "remove")
-        SetEntityHealth(ped, GetEntityHealth(ped) + 10)
+        SetEntityHealth(ped, GetEntityHealth(ped) + 25)
         if math.random(1, 100) < 50 then
             exports.qbx_medical:removeBleed(1)
         end
@@ -101,7 +99,6 @@ lib.callback.register('hospital:client:UsePainkillers', function()
     })
     then
         StopAnimTask(ped, "mp_suicide", "pill", 1.0)
-        TriggerEvent("inventory:client:ItemBox", exports.ox_inventory:Items()["painkillers"], "remove")
         OnPainKillers = true
         exports.qbx_medical:DisableDamageEffects()
         if painkillerAmount < 3 then

--- a/server/main.lua
+++ b/server/main.lua
@@ -131,23 +131,19 @@ RegisterNetEvent('hospital:server:TreatWounds', function(playerId)
 	local src = source
 	local player = exports.qbx_core:GetPlayer(src)
 	local patient = exports.qbx_core:GetPlayer(playerId)
-	if player.PlayerData.job.name ~= "ambulance" or not patient then return end
+	if player.PlayerData.job.name ~= "ambulance" or not patient or not exports.ox_inventory:RemoveItem(src, 'bandage', 1) then return end
 
-	player.Functions.RemoveItem('bandage', 1)
-	TriggerClientEvent('inventory:client:ItemBox', src, exports.ox_inventory:Items()['bandage'], "remove")
-	TriggerClientEvent("hospital:client:HealInjuries", patient.PlayerData.source, "full")
+	lib.callback("qbx_medical:client:heal", patient.PlayerData.source, false, "full")
 end)
 
 ---@param playerId number
 RegisterNetEvent('hospital:server:RevivePlayer', function(playerId)
 	if GetInvokingResource() then return end
-	local player = exports.qbx_core:GetPlayer(source)
-	local patient = exports.qbx_core:GetPlayer(playerId)
+	local src = source
+	local player = exports.qbx_core:GetPlayer(playerId)
 
-	if not patient then return end
-	player.Functions.RemoveItem('firstaid', 1)
-	TriggerClientEvent('inventory:client:ItemBox', player.PlayerData.source, exports.ox_inventory:Items()['firstaid'], "remove")
-	TriggerClientEvent('hospital:client:Revive', patient.PlayerData.source)
+	if not player or not exports.ox_inventory:RemoveItem(src, 'firstaid', 1) then return end
+	TriggerClientEvent('qbx_medical:client:playerRevived', player.PlayerData.source)
 end)
 
 local function sendDoctorAlert()
@@ -169,7 +165,7 @@ RegisterNetEvent('hospital:server:UseFirstAid', function(targetId)
 	if GetInvokingResource() then return end
 	local src = source
 	local target = exports.qbx_core:GetPlayer(targetId)
-	if not target then return end
+	if not target or not exports.ox_inventory:RemoveItem(src, 'firstaid', 1) then return end
 
 	local canHelp = lib.callback.await('hospital:client:canHelp', targetId)
 	if not canHelp then


### PR DESCRIPTION
## Description

Healing a player as ems didn't do anything. This corrects that issue and prevents players from getting stuck in a bed. Items are also now removed when using them. Also adjusted the amounts healed to be more reasonable.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
