### PR TITLE
bugfix: store vehicle, getclosestplayer, banking

### DIFF
--- a/client/job.lua
+++ b/client/job.lua
@@ -78,8 +78,8 @@ end
 ---Check status of nearest player and show treatment menu.
 ---Intended to be invoked by client or server.
 RegisterNetEvent('hospital:client:CheckStatus', function()
-    local player, distance = GetClosestPlayer()
-    if player == -1 or distance > 5.0 then
+    local player = GetClosestPlayer()
+    if not player then
         exports.qbx_core:Notify(Lang:t('error.no_player'), 'error')
         return
     end
@@ -119,8 +119,8 @@ RegisterNetEvent('hospital:client:RevivePlayer', function()
         return
     end
 
-    local player, distance = GetClosestPlayer()
-    if player == -1 or distance >= 5.0 then
+    local player = GetClosestPlayer()
+    if not player then
         exports.qbx_core:Notify(Lang:t('error.no_player'), 'error')
         return
     end
@@ -160,8 +160,8 @@ RegisterNetEvent('hospital:client:TreatWounds', function()
         return
     end
 
-    local player, distance = GetClosestPlayer()
-    if player == -1 or distance >= 5.0 then
+    local player = GetClosestPlayer()
+    if not player then
         exports.qbx_core:Notify(Lang:t('error.no_player'), 'error')
         return
     end
@@ -219,7 +219,7 @@ local function checkGarageAction(vehicles, vehiclePlatePrefix, coords)
                 lib.hideTextUI()
                 checkVehicle = false
                 if cache.vehicle then
-                    exports.qbx_core:DeleteVehicle(cache.vehicle)
+                    DeleteEntity(cache.vehicle)
                 else
                     showGarageMenu(vehicles, vehiclePlatePrefix, coords)
                 end

--- a/client/laststand.lua
+++ b/client/laststand.lua
@@ -13,8 +13,8 @@ lib.callback.register('hospital:client:UseFirstAid', function()
         return
     end
         
-    local player, distance = GetClosestPlayer()
-    if player ~= -1 and distance < 1.5 then
+    local player = GetClosestPlayer()
+    if player then
         local playerId = GetPlayerServerId(player)
         TriggerServerEvent('hospital:server:UseFirstAid', playerId)
     end

--- a/client/main.lua
+++ b/client/main.lua
@@ -99,8 +99,7 @@ CreateThread(function()
 end)
 
 function GetClosestPlayer()
-    local coords = GetEntityCoords(cache.ped)
-    return exports.qbx_core:GetClosestPlayer(coords)
+    return lib.getClosestPlayer(GetEntityCoords(cache.ped), 5.0, false)
 end
 
 function OnKeyPress(cb)

--- a/config/server.lua
+++ b/config/server.lua
@@ -1,4 +1,7 @@
 return {
     doctorCallCooldown = 1, -- Time in minutes for cooldown between doctors calls
     wipeInvOnRespawn = true, -- Enable ro disable removing all items from player on respawn
+    depositSociety = function(society, amount)
+        exports['Renewed-Banking']:addAccountMoney(society, amount)
+    end
 }

--- a/server/main.lua
+++ b/server/main.lua
@@ -19,7 +19,7 @@ end
 ---@param player Player
 local function billPlayer(player)
 	player.Functions.RemoveMoney("bank", sharedConfig.checkInCost, "respawned-at-hospital")
-	exports.qbx_management:AddMoney("ambulance", sharedConfig.checkInCost)
+	exports['Renewed-Banking']:addAccountMoney("ambulance", sharedConfig.checkInCost)
 	TriggerClientEvent('hospital:client:SendBillEmail', player.PlayerData.source, sharedConfig.checkInCost)
 end
 
@@ -86,7 +86,7 @@ lib.callback.register('qbx_ambulancejob:server:isBedTaken', function(_, hospital
 end)
 
 lib.callback.register('qbx_ambulancejob:server:getPlayerStatus', function(_, targetSrc)
-	return exports.qbx_medical:getPlayerStatus(targetSrc)
+	return exports.qbx_medical:GetPlayerStatus(targetSrc)
 end)
 
 local function alertAmbulance(src, text)

--- a/server/main.lua
+++ b/server/main.lua
@@ -19,7 +19,7 @@ end
 ---@param player Player
 local function billPlayer(player)
 	player.Functions.RemoveMoney("bank", sharedConfig.checkInCost, "respawned-at-hospital")
-	exports['Renewed-Banking']:addAccountMoney("ambulance", sharedConfig.checkInCost)
+	config.depositSociety("ambulance", sharedConfig.checkInCost)
 	TriggerClientEvent('hospital:client:SendBillEmail', player.PlayerData.source, sharedConfig.checkInCost)
 end
 


### PR DESCRIPTION
## Description

This reworks the logics for the distance checks to use the ox_lib variety which automatically excludes the calling player. This corrects a call to an old export of qbx_management which is handled by Renewed-Banking now. Also fixes an issue with a call to a qbx_medical export what is a different case.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
