### PR TITLE
Fix authorizedHelicopterS typo and removed export hasitem

### DIFF
--- a/client/job.lua
+++ b/client/job.lua
@@ -114,7 +114,7 @@ end)
 ---Use first aid on nearest player to revive them.
 ---Intended to be invoked by client or server.
 RegisterNetEvent('hospital:client:RevivePlayer', function()
-    if not exports.qbx_core:HasItem('firstaid') then
+    if not HasItem('firstaid') then
         exports.qbx_core:Notify(Lang:t('error.no_firstaid'), 'error')
         return
     end
@@ -155,7 +155,7 @@ end)
 ---Use bandage on nearest player to treat their wounds.
 ---Intended to be invoked by client or server.
 RegisterNetEvent('hospital:client:TreatWounds', function()
-    if not exports.qbx_core:HasItem('bandage') then
+    if not HasItem('bandage') then
         exports.qbx_core:Notify(Lang:t('error.no_bandage'), 'error')
         return
     end
@@ -300,7 +300,7 @@ CreateThread(function()
     end
 
     for _, coords in pairs(sharedConfig.locations.helicopter) do
-        createGarage(config.authorizedHelicopters, Lang:t('info.heli_plate'), coords)
+        createGarage(config.authorizedHelicopter, Lang:t('info.heli_plate'), coords)
     end
 end)
 


### PR DESCRIPTION
## Description

There was a typo on the authorizedHelicopter config vaue, on the client file was called authorizedHelicopters.

Trere was also an export for HasItem "exports.qbx_core:HasItem" but HasItem should be called directly.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
