### PR TITLE
refactor: style fixes

### DIFF
--- a/client/hospital.lua
+++ b/client/hospital.lua
@@ -22,7 +22,7 @@ local function setBedCam()
     bedObject = GetClosestObjectOfType(bedOccupyingData.coords.x, bedOccupyingData.coords.y, bedOccupyingData.coords.z, 1.0, bedOccupyingData.model, false, false, false)
     FreezeEntityPosition(bedObject, true)
 
-    SetEntityCoords(player, bedOccupyingData.coords.x, bedOccupyingData.coords.y, bedOccupyingData.coords.z + 0.02)
+    SetEntityCoords(cache.ped, bedOccupyingData.coords.x, bedOccupyingData.coords.y, bedOccupyingData.coords.z + 0.02)
     Wait(500)
     FreezeEntityPosition(cache.ped, true)
 

--- a/client/hospital.lua
+++ b/client/hospital.lua
@@ -8,17 +8,15 @@ local bedIndexOccupying = nil
 
 ---Teleports the player to lie down in bed and sets the player's camera.
 local function setBedCam()
-    local player = cache.ped
-
     DoScreenFadeOut(1000)
 
     while not IsScreenFadedOut() do
         Wait(100)
     end
 
-    if IsPedDeadOrDying(player) then
-        local pos = GetEntityCoords(player, true)
-        NetworkResurrectLocalPlayer(pos.x, pos.y, pos.z, GetEntityHeading(player), true, false)
+    if IsPedDeadOrDying(cache.ped) then
+        local pos = GetEntityCoords(cache.ped, true)
+        NetworkResurrectLocalPlayer(pos.x, pos.y, pos.z, GetEntityHeading(cache.ped), true, false)
     end
 
     bedObject = GetClosestObjectOfType(bedOccupyingData.coords.x, bedOccupyingData.coords.y, bedOccupyingData.coords.z, 1.0, bedOccupyingData.model, false, false, false)
@@ -26,26 +24,26 @@ local function setBedCam()
 
     SetEntityCoords(player, bedOccupyingData.coords.x, bedOccupyingData.coords.y, bedOccupyingData.coords.z + 0.02)
     Wait(500)
-    FreezeEntityPosition(player, true)
+    FreezeEntityPosition(cache.ped, true)
 
     lib.requestAnimDict(InBedDict)
 
-    TaskPlayAnim(player, InBedDict, InBedAnim, 8.0, 1.0, -1, 1, 0, false, false, false)
-    SetEntityHeading(player, bedOccupyingData.coords.w)
+    TaskPlayAnim(cache.ped, InBedDict, InBedAnim, 8.0, 1.0, -1, 1, 0, false, false, false)
+    SetEntityHeading(cache.ped, bedOccupyingData.coords.w)
 
-    cam = CreateCam("DEFAULT_SCRIPTED_CAMERA", true)
+    cam = CreateCam('DEFAULT_SCRIPTED_CAMERA', true)
     SetCamActive(cam, true)
     RenderScriptCams(true, false, 1, true, true)
-    AttachCamToPedBone(cam, player, 31085, 0, 1.0, 1.0, true)
+    AttachCamToPedBone(cam, cache.ped, 31085, 0, 1.0, 1.0, true)
     SetCamFov(cam, 90.0)
-    local heading = GetEntityHeading(player)
+    local heading = GetEntityHeading(cache.ped)
     heading = (heading > 180) and heading - 180 or heading + 180
     SetCamRot(cam, -45.0, 0.0, heading, 2)
 
     DoScreenFadeIn(1000)
 
     Wait(1000)
-    FreezeEntityPosition(player, true)
+    FreezeEntityPosition(cache.ped, true)
 end
 
 local function putPlayerInBed(hospitalName, bedIndex, isRevive, skipOpenCheck)
@@ -70,7 +68,7 @@ local function putPlayerInBed(hospitalName, bedIndex, isRevive, skipOpenCheck)
         if isRevive then
             exports.qbx_core:Notify(Lang:t('success.being_helped'), 'success')
             Wait(config.aiHealTimer * 1000)
-            TriggerEvent("hospital:client:Revive")
+            TriggerEvent('hospital:client:Revive')
         else
             CanLeaveBed = true
         end
@@ -120,7 +118,7 @@ if config.useTarget then
         for hospitalName, hospital in pairs(sharedConfig.locations.hospitals) do
             if hospital.checkIn then
                 exports.ox_target:addBoxZone({
-                    name = hospitalName.."_checkin",
+                    name = hospitalName..'_checkin',
                     coords = hospital.checkIn,
                     size = vec3(2, 1, 2),
                     rotation = 18,
@@ -130,7 +128,7 @@ if config.useTarget then
                             onSelect = function()
                                 checkIn(hospitalName)
                             end,
-                            icon = "fas fa-clipboard",
+                            icon = 'fas fa-clipboard',
                             label = Lang:t('text.check'),
                             distance = 1.5,
                         }
@@ -141,7 +139,7 @@ if config.useTarget then
             for i = 1, #hospital.beds do
                 local bed = hospital.beds[i]
                 exports.ox_target:addBoxZone({
-                    name = hospitalName.."_bed_"..i,
+                    name = hospitalName..'_bed_'..i,
                     coords = bed.coords.xyz,
                     size = vec3(1.7, 1.9, 2),
                     rotation = bed.coords.w,
@@ -151,7 +149,7 @@ if config.useTarget then
                             onSelect = function()
                                 putPlayerInBed(hospitalName, i, false)
                             end,
-                            icon = "fas fa-clipboard",
+                            icon = 'fas fa-clipboard',
                             label = Lang:t('text.bed'),
                             distance = 1.5,
                         },
@@ -166,7 +164,7 @@ if config.useTarget then
                                     TriggerServerEvent('hospital:server:putPlayerInBed', playerId, hospitalName, i)
                                 end
                             end,
-                            icon = "fas fa-clipboard",
+                            icon = 'fas fa-clipboard',
                             label = Lang:t('text.put_bed'),
                             distance = 1.5,
                         }
@@ -210,7 +208,7 @@ else
                     inside = insideCheckInZone,
                 })
             end
-            
+
             for i = 1, #hospital.beds do
                 local bed = hospital.beds[i]
                 local function enterBedZone()
@@ -244,19 +242,15 @@ else
     end)
 end
 
----plays animation to get out of bed and resets variables
+---Plays animation to get out of bed and resets variables
 local function leaveBed()
-    local ped = cache.ped
-    local getOutDict = 'switch@franklin@bed'
-    local getOutAnim = 'sleep_getup_rubeyes'
-
-    lib.requestAnimDict(getOutDict)
-    FreezeEntityPosition(ped, false)
-    SetEntityInvincible(ped, false)
-    SetEntityHeading(ped, bedOccupyingData.coords.w + 90)
-    TaskPlayAnim(ped, getOutDict, getOutAnim, 100.0, 1.0, -1, 8, -1, false, false, false)
+    lib.requestAnimDict('switch@franklin@bed')
+    FreezeEntityPosition(cache.ped, false)
+    SetEntityInvincible(cache.ped, false)
+    SetEntityHeading(cache.ped, bedOccupyingData.coords.w + 90)
+    TaskPlayAnim(cache.ped, 'switch@franklin@bed', 'sleep_getup_rubeyes', 100.0, 1.0, -1, 8, -1, false, false, false)
     Wait(4000)
-    ClearPedTasks(ped)
+    ClearPedTasks(cache.ped)
     TriggerServerEvent('qbx_ambulancejob:server:playerLeftBed', hospitalOccupying, bedIndexOccupying)
     FreezeEntityPosition(bedObject, true)
     RenderScriptCams(false, true, 200, true, true)
@@ -270,10 +264,10 @@ local function leaveBed()
     exports.qbx_medical:EnableDamageEffects()
 
     if QBX.PlayerData.metadata.injail <= 0 then return end
-    TriggerEvent("prison:client:Enter", QBX.PlayerData.metadata.injail)
+    TriggerEvent('prison:client:Enter', QBX.PlayerData.metadata.injail)
 end
 
----shows player option to press key to leave bed when available.
+---Shows player option to press key to leave bed when available.
 CreateThread(function()
     while true do
         if IsInHospitalBed and CanLeaveBed then
@@ -289,7 +283,7 @@ CreateThread(function()
     end
 end)
 
----reset player settings that the server is storing
+---Reset player settings that the server is storing
 local function onPlayerUnloaded()
     if bedIndexOccupying then
         TriggerServerEvent('qbx_ambulancejob:server:playerLeftBed', hospitalOccupying, bedIndexOccupying)
@@ -299,6 +293,6 @@ end
 RegisterNetEvent('QBCore:Client:OnPlayerUnload', onPlayerUnloaded)
 
 AddEventHandler('onResourceStop', function(resourceName)
-    if GetCurrentResourceName() ~= resourceName then return end
+    if cache.resource ~= resourceName then return end
     onPlayerUnloaded()
 end)

--- a/client/job.lua
+++ b/client/job.lua
@@ -14,14 +14,14 @@ local function takeOutVehicle(data)
     end
     local veh = NetworkGetEntityFromNetworkId(netId)
     SetVehicleNumberPlateText(veh, data.vehiclePlatePrefix .. tostring(math.random(1000, 9999)))
-    TriggerEvent("vehiclekeys:client:SetOwner", GetPlate(veh))
+    TriggerEvent('vehiclekeys:client:SetOwner', GetPlate(veh))
     SetVehicleEngineOn(veh, true, true, true)
 
     local settings = config.vehicleSettings[data.vehicleName]
     if not settings then return end
 
     if settings.extras then
-        SetVehicleExtras(veh, settings.extras)
+        SetVehicleExtra(veh, settings.extras)
     end
 
     if settings.livery then
@@ -29,7 +29,7 @@ local function takeOutVehicle(data)
     end
 end
 
----show the garage spawn menu
+---Show the garage spawn menu
 ---@param vehicles AuthorizedVehicles
 ---@param vehiclePlatePrefix string
 ---@param coords vector4
@@ -56,14 +56,14 @@ local function showGarageMenu(vehicles, vehiclePlatePrefix, coords)
     lib.showContext('ambulance_garage_context_menu')
 end
 
----show patient's treatment menu.
+---Show patient's treatment menu.
 ---@param status string[]
 local function showTreatmentMenu(status)
     local statusMenu = {}
     for i=1, #status do
         statusMenu[i] = {
             title = status[i],
-            event = "hospital:client:TreatWounds",
+            event = 'hospital:client:TreatWounds',
         }
     end
 
@@ -144,11 +144,11 @@ RegisterNetEvent('hospital:client:RevivePlayer', function()
         },
     })
     then
-        StopAnimTask(cache.ped, HealAnimDict, "exit", 1.0)
+        StopAnimTask(cache.ped, HealAnimDict, 'exit', 1.0)
         exports.qbx_core:Notify(Lang:t('success.revived'), 'success')
-        TriggerServerEvent("hospital:server:RevivePlayer", GetPlayerServerId(player))
+        TriggerServerEvent('hospital:server:RevivePlayer', GetPlayerServerId(player))
     else
-        StopAnimTask(cache.ped, HealAnimDict, "exit", 1.0)
+        StopAnimTask(cache.ped, HealAnimDict, 'exit', 1.0)
         exports.qbx_core:Notify(Lang:t('error.canceled'), 'error')
     end
 end)
@@ -186,11 +186,11 @@ RegisterNetEvent('hospital:client:TreatWounds', function()
         },
     })
     then
-        StopAnimTask(cache.ped, HealAnimDict, "exit", 1.0)
+        StopAnimTask(cache.ped, HealAnimDict, 'exit', 1.0)
         exports.qbx_core:Notify(Lang:t('success.helped_player'), 'success')
-        TriggerServerEvent("hospital:server:TreatWounds", GetPlayerServerId(player))
+        TriggerServerEvent('hospital:server:TreatWounds', GetPlayerServerId(player))
     else
-        StopAnimTask(cache.ped, HealAnimDict, "exit", 1.0)
+        StopAnimTask(cache.ped, HealAnimDict, 'exit', 1.0)
         exports.qbx_core:Notify(Lang:t('error.canceled'), 'error')
     end
 end)
@@ -198,18 +198,18 @@ end)
 ---Opens the hospital stash.
 local function openStash()
     if not QBX.PlayerData.job.onduty then return end
-    TriggerServerEvent("inventory:server:OpenInventory", "stash", "ambulancestash_" .. QBX.PlayerData.citizenid)
-    TriggerEvent("inventory:client:SetCurrentStash", "ambulancestash_" .. QBX.PlayerData.citizenid)
+    TriggerServerEvent('inventory:server:OpenInventory', 'stash', 'ambulancestash_' .. QBX.PlayerData.citizenid)
+    TriggerEvent('inventory:client:SetCurrentStash', 'ambulancestash_' .. QBX.PlayerData.citizenid)
 end
 
 ---Opens the hospital armory.
 local function openArmory()
     if QBX.PlayerData.job.onduty then
-        TriggerServerEvent("inventory:server:OpenInventory", "shop", "hospital", config.items)
+        TriggerServerEvent('inventory:server:OpenInventory', 'shop', 'hospital', config.items)
     end
 end
 
----while in the garage pressing a key triggers storing the current vehicle or opening spawn menu.
+---While in the garage pressing a key triggers storing the current vehicle or opening spawn menu.
 ---@param vehicles AuthorizedVehicles
 ---@param vehiclePlatePrefix string
 ---@param coords vector4
@@ -234,14 +234,13 @@ end
 ---Teleports the player with a fade in/out effect
 ---@param coords vector4
 local function teleportPlayerWithFade(coords)
-    local ped = cache.ped
     DoScreenFadeOut(500)
     while not IsScreenFadedOut() do
         Wait(10)
     end
 
-    SetEntityCoords(ped, coords.x, coords.y, coords.z, false, false, false, false)
-    SetEntityHeading(ped, coords.w)
+    SetEntityCoords(cache.ped, coords.x, coords.y, coords.z, false, false, false, false)
+    SetEntityHeading(cache.ped, coords.w)
 
     Wait(100)
 
@@ -260,18 +259,18 @@ end
 
 ---Toggles the on duty status of the player.
 local function toggleDuty()
-    TriggerServerEvent("QBCore:ToggleDuty")
-    TriggerServerEvent("police:server:UpdateBlips")
+    TriggerServerEvent('QBCore:ToggleDuty')
+    TriggerServerEvent('police:server:UpdateBlips')
 end
 
----creates a zone that lets players store and retrieve job vehicles
+---Creates a zone that lets players store and retrieve job vehicles
 ---@param vehicles AuthorizedVehicles
 ---@param vehiclePlatePrefix string
 ---@param coords vector4
 local function createGarage(vehicles, vehiclePlatePrefix, coords)
 
     local function inVehicleZone()
-        if QBX.PlayerData.job.name == "ambulance" and QBX.PlayerData.job.onduty then
+        if QBX.PlayerData.job.name == 'ambulance' and QBX.PlayerData.job.onduty then
             lib.showTextUI(Lang:t('text.veh_button'))
             checkGarageAction(vehicles, vehiclePlatePrefix, coords)
         else
@@ -311,92 +310,92 @@ if config.useTarget then
     CreateThread(function()
         for i = 1, #sharedConfig.locations.duty do
             exports.ox_target:addBoxZone({
-                name = "duty" .. i,
+                name = 'duty' .. i,
                 coords = sharedConfig.locations.duty[i],
                 size = vec3(1.5, 1, 2),
                 rotation = 71,
                 debug = config.debugPoly,
                 options = {
                     {
-                        type = "client",
+                        type = 'client',
                         onSelect = toggleDuty,
-                        icon = "fa fa-clipboard",
+                        icon = 'fa fa-clipboard',
                         label = Lang:t('text.duty'),
                         distance = 2,
-                        groups = "ambulance",
+                        groups = 'ambulance',
                     }
                 }
             })
         end
         for i = 1, #sharedConfig.locations.stash do
             exports.ox_target:addBoxZone({
-                name = "stash" .. i,
+                name = 'stash' .. i,
                 coords = sharedConfig.locations.stash[i],
                 size = vec3(1, 1, 2),
                 rotation = -20,
                 debug = config.debugPoly,
                 options = {
                     {
-                        type = "client",
+                        type = 'client',
                         onSelect = openStash,
-                        icon = "fa fa-clipboard",
+                        icon = 'fa fa-clipboard',
                         label = Lang:t('text.pstash'),
                         distance = 2,
-                        groups = "ambulance",
+                        groups = 'ambulance',
                     }
                 }
             })
         end
         for i = 1, #sharedConfig.locations.armory do
             exports.ox_target:addBoxZone({
-                name = "armory" .. i,
+                name = 'armory' .. i,
                 coords = sharedConfig.locations.armory[i],
                 size = vec3(1, 1, 2),
                 rotation = -20,
                 debug = config.debugPoly,
                 options = {
                     {
-                        type = "client",
+                        type = 'client',
                         onSelect = openArmory,
-                        icon = "fa fa-clipboard",
+                        icon = 'fa fa-clipboard',
                         label = Lang:t('text.armory'),
                         distance = 1.5,
-                        groups = "ambulance",
+                        groups = 'ambulance',
                     }
                 }
             })
         end
         exports.ox_target:addBoxZone({
-            name = "roof1",
+            name = 'roof1',
             coords = sharedConfig.locations.roof[1],
             size = vec3(1, 2, 2),
             rotation = -20,
             debug = config.debugPoly,
             options = {
                 {
-                    type = "client",
+                    type = 'client',
                     onSelect = teleportToMainElevator,
-                    icon = "fas fa-hand-point-down",
+                    icon = 'fas fa-hand-point-down',
                     label = Lang:t('text.el_main'),
                     distance = 1.5,
-                    groups = "ambulance",
+                    groups = 'ambulance',
                 }
             }
         })
         exports.ox_target:addBoxZone({
-            name = "main1",
+            name = 'main1',
             coords = sharedConfig.locations.main[1],
             size = vec3(2, 1, 2),
             rotation = -20,
             debug = config.debugPoly,
             options = {
                 {
-                    type = "client",
+                    type = 'client',
                     onSelect = teleportToRoofElevator,
-                    icon = "fas fa-hand-point-up",
+                    icon = 'fas fa-hand-point-up',
                     label = Lang:t('text.el_roof'),
                     distance = 1.5,
-                    groups = "ambulance",
+                    groups = 'ambulance',
                 }
             }
         })
@@ -441,7 +440,7 @@ else
             local function outStashZone()
                 lib.hideTextUI()
             end
-            
+
             local function insideStashZone()
                 OnKeyPress(openStash)
             end

--- a/client/laststand.lua
+++ b/client/laststand.lua
@@ -6,13 +6,13 @@ AddEventHandler('hospital:client:SetEscortingState', function(bool)
     isEscorting = bool
 end)
 
----use first aid pack on nearest player.
+---Use first aid pack on nearest player.
 lib.callback.register('hospital:client:UseFirstAid', function()
     if isEscorting then
         exports.qbx_core:Notify(Lang:t('error.impossible'), 'error')
         return
     end
-        
+
     local player = GetClosestPlayer()
     if player then
         local playerId = GetPlayerServerId(player)
@@ -27,7 +27,6 @@ end)
 ---@param targetId number playerId
 RegisterNetEvent('hospital:client:HelpPerson', function(targetId)
     if GetInvokingResource() then return end
-    local ped = cache.ped
     if lib.progressCircle({
         duration = math.random(30000, 60000),
         position = 'bottom',
@@ -46,11 +45,11 @@ RegisterNetEvent('hospital:client:HelpPerson', function(targetId)
         },
     })
     then
-        ClearPedTasks(ped)
+        ClearPedTasks(cache.ped)
         exports.qbx_core:Notify(Lang:t('success.revived'), 'success')
-        TriggerServerEvent("hospital:server:RevivePlayer", targetId)
+        TriggerServerEvent('hospital:server:RevivePlayer', targetId)
     else
-        ClearPedTasks(ped)
+        ClearPedTasks(cache.ped)
         exports.qbx_core:Notify(Lang:t('error.canceled'), 'error')
     end
 end)

--- a/client/main.lua
+++ b/client/main.lua
@@ -1,16 +1,14 @@
 local sharedConfig = require 'config.shared'
-InBedDict = "anim@gangops@morgue@table@"
-InBedAnim = "body_search"
+InBedDict = 'anim@gangops@morgue@table@'
+InBedAnim = 'body_search'
 IsInHospitalBed = false
-HealAnimDict = "mini@cpr@char_a@cpr_str"
-HealAnim = "cpr_pumpchest"
+HealAnimDict = 'mini@cpr@char_a@cpr_str'
+HealAnim = 'cpr_pumpchest'
 EmsNotified = false
 CanLeaveBed = true
 OnPainKillers = false
 
--- Events
-
----notifies EMS of a injury at a location
+---Notifies EMS of a injury at a location
 ---@param coords vector3
 ---@param text string
 RegisterNetEvent('hospital:client:ambulanceAlert', function(coords, text)
@@ -19,7 +17,7 @@ RegisterNetEvent('hospital:client:ambulanceAlert', function(coords, text)
     local street1name = GetStreetNameFromHashKey(street1)
     local street2name = GetStreetNameFromHashKey(street2)
     exports.qbx_core:Notify({ title = Lang:t('text.alert'), description = text .. ' | ' .. street1name .. ' ' .. street2name, type = 'inform' })
-    PlaySound(-1, "Lose_1st", "GTAO_FM_Events_Soundset", 0, 0, 1)
+    PlaySound(-1, 'Lose_1st', 'GTAO_FM_Events_Soundset', 0, 0, 1)
     local transG = 250
     local blip = AddBlipForCoord(coords.x, coords.y, coords.z)
     local blip2 = AddBlipForCoord(coords.x, coords.y, coords.z)
@@ -55,18 +53,17 @@ end)
 ---Revives player, healing all injuries
 ---Intended to be called from client or server.
 RegisterNetEvent('hospital:client:Revive', function()
-    local ped = cache.ped
     if IsInHospitalBed then
         lib.requestAnimDict(InBedDict)
-        TaskPlayAnim(ped, InBedDict, InBedAnim, 8.0, 1.0, -1, 1, 0, 0, 0, 0)
-        SetEntityInvincible(ped, true)
+        TaskPlayAnim(cache.ped, InBedDict, InBedAnim, 8.0, 1.0, -1, 1, 0, false, false, false)
+        SetEntityInvincible(cache.ped, true)
         CanLeaveBed = true
     end
 
     EmsNotified = false
 end)
 
----sends player phone email with hospital bill.
+---Sends player phone email with hospital bill.
 ---@param amount number
 RegisterNetEvent('hospital:client:SendBillEmail', function(amount)
     if GetInvokingResource() then return end
@@ -82,9 +79,7 @@ RegisterNetEvent('hospital:client:SendBillEmail', function(amount)
     end)
 end)
 
--- Threads
-
----sets blips for stations on map
+---Sets blips for stations on map
 CreateThread(function()
     for _, station in pairs(sharedConfig.locations.stations) do
         local blip = AddBlipForCoord(station.coords.x, station.coords.y, station.coords.z)
@@ -92,7 +87,7 @@ CreateThread(function()
         SetBlipAsShortRange(blip, true)
         SetBlipScale(blip, 0.8)
         SetBlipColour(blip, 25)
-        BeginTextCommandSetBlipName("STRING")
+        BeginTextCommandSetBlipName('STRING')
         AddTextComponentString(station.label)
         EndTextCommandSetBlipName(blip)
     end

--- a/client/wounding.lua
+++ b/client/wounding.lua
@@ -1,10 +1,8 @@
 local config = require 'config.client'
 local painkillerAmount = 0
-
--- Events
+local ITEMS = exports.ox_inventory:Items()
 
 lib.callback.register('hospital:client:UseIfaks', function()
-    local ped = cache.ped
     if lib.progressCircle({
         duration = 3000,
         position = 'bottom',
@@ -18,15 +16,15 @@ lib.callback.register('hospital:client:UseIfaks', function()
             mouse = false,
         },
         anim = {
-            dict = "mp_suicide",
-            clip = "pill",
+            dict = 'mp_suicide',
+            clip = 'pill',
         },
     })
     then
-        StopAnimTask(ped, "mp_suicide", "pill", 1.0)
-        TriggerEvent("inventory:client:ItemBox", exports.ox_inventory:Items()["ifaks"], "remove")
+        StopAnimTask(cache.ped, 'mp_suicide', 'pill', 1.0)
+        TriggerEvent('inventory:client:ItemBox', ITEMS['ifaks'], 'remove')
         TriggerServerEvent('hud:server:RelieveStress', math.random(12, 24))
-        SetEntityHealth(ped, GetEntityHealth(ped) + 10)
+        SetEntityHealth(cache.ped, GetEntityHealth(cache.ped) + 10)
         OnPainKillers = true
         exports.qbx_medical:DisableDamageEffects()
         if painkillerAmount < 3 then
@@ -37,14 +35,13 @@ lib.callback.register('hospital:client:UseIfaks', function()
         end
         return true
     else
-        StopAnimTask(ped, "mp_suicide", "pill", 1.0)
+        StopAnimTask(cache.ped, 'mp_suicide', 'pill', 1.0)
         exports.qbx_core:Notify(Lang:t('error.canceled'), 'error')
         return false
     end
 end)
 
 lib.callback.register('hospital:client:UseBandage', function()
-    local ped = cache.ped
     if lib.progressCircle({
         duration = 4000,
         position = 'bottom',
@@ -58,14 +55,14 @@ lib.callback.register('hospital:client:UseBandage', function()
             mouse = false,
         },
         anim = {
-            dict = "mp_suicide",
-            clip = "pill",
+            dict = 'mp_suicide',
+            clip = 'pill',
         },
     })
     then
-        StopAnimTask(ped, "anim@amb@business@weed@weed_inspecting_high_dry@", "weed_inspecting_high_base_inspector", 1.0)
-        TriggerEvent("inventory:client:ItemBox", exports.ox_inventory:Items()["bandage"], "remove")
-        SetEntityHealth(ped, GetEntityHealth(ped) + 10)
+        StopAnimTask(cache.ped, 'anim@amb@business@weed@weed_inspecting_high_dry@', 'weed_inspecting_high_base_inspector', 1.0)
+        TriggerEvent('inventory:client:ItemBox', ITEMS['bandage'], 'remove')
+        SetEntityHealth(cache.ped, GetEntityHealth(cache.ped) + 10)
         if math.random(1, 100) < 50 then
             exports.qbx_medical:removeBleed(1)
         end
@@ -74,14 +71,13 @@ lib.callback.register('hospital:client:UseBandage', function()
         end
         return true
     else
-        StopAnimTask(ped, "anim@amb@business@weed@weed_inspecting_high_dry@", "weed_inspecting_high_base_inspector", 1.0)
+        StopAnimTask(cache.ped, 'anim@amb@business@weed@weed_inspecting_high_dry@', 'weed_inspecting_high_base_inspector', 1.0)
         exports.qbx_core:Notify(Lang:t('error.canceled'), 'error')
         return false
     end
 end)
 
 lib.callback.register('hospital:client:UsePainkillers', function()
-    local ped = cache.ped
     if lib.progressCircle({
         duration = 3000,
         position = 'bottom',
@@ -95,13 +91,13 @@ lib.callback.register('hospital:client:UsePainkillers', function()
             mouse = false,
         },
         anim = {
-            dict = "mp_suicide",
-            clip = "pill",
+            dict = 'mp_suicide',
+            clip = 'pill',
         },
     })
     then
-        StopAnimTask(ped, "mp_suicide", "pill", 1.0)
-        TriggerEvent("inventory:client:ItemBox", exports.ox_inventory:Items()["painkillers"], "remove")
+        StopAnimTask(cache.ped, 'mp_suicide', 'pill', 1.0)
+        TriggerEvent('inventory:client:ItemBox', ITEMS['painkillers'], 'remove')
         OnPainKillers = true
         exports.qbx_medical:DisableDamageEffects()
         if painkillerAmount < 3 then
@@ -109,7 +105,7 @@ lib.callback.register('hospital:client:UsePainkillers', function()
         end
         return true
     else
-        StopAnimTask(ped, "mp_suicide", "pill", 1.0)
+        StopAnimTask(cache.ped, 'mp_suicide', 'pill', 1.0)
         exports.qbx_core:Notify(Lang:t('error.canceled'), 'error')
         return false
     end

--- a/server/hospital.lua
+++ b/server/hospital.lua
@@ -31,8 +31,8 @@ end)
 
 ---@param player Player
 local function billPlayer(player)
-	player.Functions.RemoveMoney("bank", sharedConfig.checkInCost, "respawned-at-hospital")
-	config.depositSociety("ambulance", sharedConfig.checkInCost)
+	player.Functions.RemoveMoney('bank', sharedConfig.checkInCost, 'respawned-at-hospital')
+	config.depositSociety('ambulance', sharedConfig.checkInCost)
 	TriggerClientEvent('hospital:client:SendBillEmail', player.PlayerData.source, sharedConfig.checkInCost)
 end
 
@@ -62,7 +62,7 @@ end)
 ---@param player Player
 local function wipeInventory(player)
 	player.Functions.ClearInventory()
-	TriggerClientEvent('ox_lib:notify', player.PlayerData.source, { description = Lang:t('error.possessions_taken'), type = 'error' })
+	exports.qbx_core:Notify(player.PlayerData.source, Lang:t('error.possessions_taken'), 'error')
 end
 
 lib.callback.register('qbx_ambulancejob:server:spawnVehicle', function(source, vehicleName, vehicleCoords)
@@ -76,7 +76,7 @@ local function sendDoctorAlert()
 	local _, doctors = exports.qbx_core:GetDutyCountType('ems')
 	for i = 1, #doctors do
 		local doctor = doctors[i]
-		TriggerClientEvent('ox_lib:notify', doctor, { description = Lang:t('info.dr_needed'), type = 'inform' })
+		exports.qbx_core:Notify(doctor, Lang:t('info.dr_needed'), 'inform')
 	end
 
 	SetTimeout(config.doctorCallCooldown * 60000, function()
@@ -87,7 +87,7 @@ end
 local function canCheckIn(source, hospitalName)
 	local numDoctors = exports.qbx_core:GetDutyCountType('ems')
 	if numDoctors >= sharedConfig.minForCheckIn then
-		TriggerClientEvent('ox_lib:notify', source, { description = Lang:t('info.dr_alert'), type = 'inform' })
+		exports.qbx_core:Notify(source, Lang:t('info.dr_alert'), 'inform')
 		sendDoctorAlert()
 		return false
 	end
@@ -127,7 +127,7 @@ local function respawn(src)
 	local player = exports.qbx_core:GetPlayer(src)
 	local closestHospital
 	if player.PlayerData.metadata.injail > 0 then
-		closestHospital = "jail"
+		closestHospital = 'jail'
 	else
 		local coords = GetEntityCoords(GetPlayerPed(src))
 		local closest = nil

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,3 +1,5 @@
+local ITEMS = exports.ox_inventory:Items()
+
 ---@alias source number
 
 lib.callback.register('qbx_ambulancejob:server:getPlayerStatus', function(_, targetSrc)
@@ -33,11 +35,11 @@ RegisterNetEvent('hospital:server:TreatWounds', function(playerId)
 	local src = source
 	local player = exports.qbx_core:GetPlayer(src)
 	local patient = exports.qbx_core:GetPlayer(playerId)
-	if player.PlayerData.job.name ~= "ambulance" or not patient then return end
+	if player.PlayerData.job.name ~= 'ambulance' or not patient then return end
 
 	player.Functions.RemoveItem('bandage', 1)
-	TriggerClientEvent('inventory:client:ItemBox', src, exports.ox_inventory:Items()['bandage'], "remove")
-	TriggerClientEvent("hospital:client:HealInjuries", patient.PlayerData.source, "full")
+	TriggerClientEvent('inventory:client:ItemBox', src, ITEMS['bandage'], 'remove')
+	TriggerClientEvent('hospital:client:HealInjuries', patient.PlayerData.source, 'full')
 end)
 
 ---@param playerId number
@@ -48,7 +50,7 @@ RegisterNetEvent('hospital:server:RevivePlayer', function(playerId)
 
 	if not patient then return end
 	player.Functions.RemoveItem('firstaid', 1)
-	TriggerClientEvent('inventory:client:ItemBox', player.PlayerData.source, exports.ox_inventory:Items()['firstaid'], "remove")
+	TriggerClientEvent('inventory:client:ItemBox', player.PlayerData.source, ITEMS['firstaid'], 'remove')
 	TriggerClientEvent('qbx_medical:client:playerRevived', patient.PlayerData.source)
 end)
 
@@ -61,26 +63,22 @@ RegisterNetEvent('hospital:server:UseFirstAid', function(targetId)
 
 	local canHelp = lib.callback.await('hospital:client:canHelp', targetId)
 	if not canHelp then
-		TriggerClientEvent('ox_lib:notify', src, { description = Lang:t('error.cant_help'), type = 'error' })
+		exports.qbx_core:Notify(src, Lang:t('error.cant_help'), 'error')
 		return
 	end
 
 	TriggerClientEvent('hospital:client:HelpPerson', src, targetId)
 end)
 
--- Callbacks
-
 lib.callback.register('qbx_ambulancejob:server:getNumDoctors', function()
 	local count = exports.qbx_core:GetDutyCountType('ems')
 	return count
 end)
 
--- Commands
-
 lib.addCommand('911e', {
     help = Lang:t('info.ems_report'),
     params = {
-        { name = 'message', help = Lang:t('info.message_sent'), type = 'string', optional = true},
+        {name = 'message', help = Lang:t('info.message_sent'), type = 'string', optional = true},
     }
 }, function(source, args)
 	local message = args.message or Lang:t('info.civ_call')
@@ -98,8 +96,8 @@ end)
 ---@param event string
 local function triggerEventOnEmsPlayer(src, event)
 	local player = exports.qbx_core:GetPlayer(src)
-	if player.PlayerData.job.name ~= "ambulance" then
-		TriggerClientEvent('ox_lib:notify', src, { description = Lang:t('error.not_ems'), type = 'error' })
+	if player.PlayerData.job.name ~= 'ambulance' then
+		exports.qbx_core:Notify(src, Lang:t('error.not_ems'), 'error')
 		return
 	end
 
@@ -136,19 +134,19 @@ local function triggerItemEventOnPlayer(src, item, event)
 	player.Functions.RemoveItem(item.name, 1)
 end
 
-exports.qbx_core:CreateUseableItem("ifaks", function(source, item)
+exports.qbx_core:CreateUseableItem('ifaks', function(source, item)
 	triggerItemEventOnPlayer(source, item, 'hospital:client:UseIfaks')
 end)
 
-exports.qbx_core:CreateUseableItem("bandage", function(source, item)
+exports.qbx_core:CreateUseableItem('bandage', function(source, item)
 	triggerItemEventOnPlayer(source, item, 'hospital:client:UseBandage')
 end)
 
-exports.qbx_core:CreateUseableItem("painkillers", function(source, item)
+exports.qbx_core:CreateUseableItem('painkillers', function(source, item)
 	triggerItemEventOnPlayer(source, item, 'hospital:client:UsePainkillers')
 end)
 
-exports.qbx_core:CreateUseableItem("firstaid", function(source, item)
+exports.qbx_core:CreateUseableItem('firstaid', function(source, item)
 	triggerItemEventOnPlayer(source, item, 'hospital:client:UseFirstAid')
 end)
 


### PR DESCRIPTION
## Description

- Standardize the use of ' over "
- Proper usage of ox caching
- Capitalization of comments
- Constant variables instead of exports.ox_inventory:Items()
- Finish the switch from ox_lib:notify to qbx_core:Notify on the serverside
- Fix the SetVehicleExtra usage

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
