### PR TITLE
fix(client/main): not revived when checking in

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -56,7 +56,7 @@ RegisterNetEvent('hospital:client:Revive', function()
     if IsInHospitalBed then
         lib.requestAnimDict(InBedDict)
         TaskPlayAnim(cache.ped, InBedDict, InBedAnim, 8.0, 1.0, -1, 1, 0, false, false, false)
-        SetEntityInvincible(cache.ped, true)
+        TriggerEvent('qbx_medical:client:playerRevived')
         CanLeaveBed = true
     end
 


### PR DESCRIPTION
## Description

Previously when checking in, the player would go through the process without being revived. This fixes that issue.

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
