### PR TITLE
Update setdownedstate.lua | Phone Disabling While Dead

### DIFF
--- a/client/setdownedstate.lua
+++ b/client/setdownedstate.lua
@@ -62,20 +62,24 @@ local function handleLastStand()
     end
 end
 
----Set dead and last stand states.
 CreateThread(function()
     while true do
         local isDead = exports.qbx_medical:IsDead()
         local inLaststand = exports.qbx_medical:IsLaststand()
         if isDead or inLaststand then
             if isDead then
+                exports.npwd:setPhoneVisible(false)
+                exports.npwd:setPhoneDisabled(true)
                 handleDead(cache.ped)
             elseif inLaststand then
+                exports.npwd:setPhoneVisible(false)
+                exports.npwd:setPhoneDisabled(true)
                 handleLastStand()
             end
             Wait(0)
         else
             Wait(1000)
+            exports.npwd:setPhoneDisabled(false)
         end
     end
 end)


### PR DESCRIPTION
Added NPWD exports to disable the phone and check if the phone is visible before death, then hiding it after the player is in the isDead state.

## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? --> It fixes the phone usage while dead, and it should be merged cause its a bug.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x ] My pull request fits the contribution guidelines & code conventions.
