### PR TITLE
fix: Don't poll globally if the player doesn't need it

### DIFF
--- a/client/setdownedstate.lua
+++ b/client/setdownedstate.lua
@@ -64,6 +64,7 @@ end
 
 ---Set dead and last stand states.
 CreateThread(function()
+    local lastUpdate = GetGameTimer()
     while true do
         local isDead = exports.qbx_medical:IsDead()
         local inLaststand = exports.qbx_medical:IsLaststand()
@@ -73,16 +74,16 @@ CreateThread(function()
             elseif inLaststand then
                 handleLastStand()
             end
+
+            local currentTime = GetGameTimer()
+            if (currentTime - lastUpdate) > 60000 then
+                doctorCount = getDoctorCount()
+                lastUpdate = currentTime
+            end
+
             Wait(0)
         else
             Wait(1000)
         end
-    end
-end)
-
-CreateThread(function()
-    while true do
-        doctorCount = getDoctorCount()
-        Wait(60000)
     end
 end)


### PR DESCRIPTION
## Description

My pull request fixes a massive network and server performance issue by making it so that doctorCount is only polled by the people who are down and need the data and not by the entire population every 60 seconds.

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X] My pull request fits the contribution guidelines & code conventions.
