### PR TITLE
feat: Add client side checkIn event

### DIFF
--- a/client/hospital.lua
+++ b/client/hospital.lua
@@ -122,6 +122,10 @@ local function checkIn(hospitalName)
     end
 end
 
+RegisterNetEvent('qbx_ambulancejob:client:checkIn', function(hospitalName)
+    checkIn(hospitalName)
+end)
+
 RegisterNetEvent('qbx_ambulancejob:client:checkedIn', function(hospitalName, bedIndex)
     putPlayerInBed(hospitalName, bedIndex, true, true)
 end)


### PR DESCRIPTION
## Description

This PR registers a new client side net event `qbx_ambulancejob:client:checkIn`. 
This event simply calls the existing `checkIn` function. 

This event provides an easy way for external scripts to utilize the existing checkIn functionality. 

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
