### PR TITLE
fix(server): exploitable "RevivePlayer" Event

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -56,8 +56,11 @@ RegisterNetEvent('hospital:server:TreatWounds', function(playerId)
 	local patient = exports.qbx_core:GetPlayer(playerId)
 	if player.PlayerData.job.type ~= 'ems' or not patient then return end
 
-	exports.ox_inventory:RemoveItem(src, 'bandage', 1)
-	TriggerClientEvent('hospital:client:HealInjuries', patient.PlayerData.source, 'full')
+	if exports.ox_inventory:RemoveItem(src, 'bandage', 1) then
+        TriggerClientEvent('hospital:client:HealInjuries', patient.PlayerData.source, 'full')
+    else
+        exports.qbx_core:Notify(src, locale('error.no_bandage'), 'error')
+    end
 end)
 
 ---@param playerId number
@@ -65,11 +68,18 @@ RegisterNetEvent('hospital:server:RevivePlayer', function(playerId)
 	if GetInvokingResource() then return end
 	local player = exports.qbx_core:GetPlayer(source)
 	local patient = exports.qbx_core:GetPlayer(playerId)
-
 	if not patient then return end
 
-	exports.ox_inventory:RemoveItem(player.PlayerData.source, 'firstaid', 1)
-	TriggerClientEvent('qbx_medical:client:playerRevived', patient.PlayerData.source)
+    if player.PlayerData.job.type ~= 'ems' then
+        lib.logger(source, 'RevivePlayer', ('"%s" triggered event for "%s" bus was missing the required job'):format(player.PlayerData.citizenid, patient.PlayerData.citizenid or ''))
+        return
+    end
+
+	if exports.ox_inventory:RemoveItem(player.PlayerData.source, 'firstaid', 1) then
+        TriggerClientEvent('qbx_medical:client:playerRevived', patient.PlayerData.source)
+    else
+        exports.qbx_core:Notify(player.PlayerData.source, locale('error.no_firstaid'), 'error')
+    end
 end)
 
 ---@param targetId number


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
It fixes an exploitable event in qbx_ambulancejob which would allow to trigger this event from the client without having the required job. also it tried to remove the item but never checked if it was successfull. https://github.com/Qbox-project/qbx_adminmenu/issues/80

You could easily trigger the event before and revive yourself or others. see below
```lua
-- revive yourself instantly
TriggerServerEvent('hospital:server:RevivePlayer, GetPlayerServerId(PlayerId()))
```
I fixed this by adding small changes to the code.
```lua
RegisterNetEvent('hospital:server:RevivePlayer', function(playerId)
    if GetInvokingResource() then return end
    local player = exports.qbx_core:GetPlayer(source)
    local patient = exports.qbx_core:GetPlayer(playerId)
    if not patient then return end
   
    -- now checks if job type is "ems"
    if player.PlayerData.job.type ~= 'ems' then
        lib.logger(source, 'RevivePlayer', ('"%s" triggered event for "%s" bus was missing the required job'):format(player.PlayerData.citizenid, patient.PlayerData.citizenid or ''))
        return
    end

	if exports.ox_inventory:RemoveItem(player.PlayerData.source, 'firstaid', 1) then
        TriggerClientEvent('qbx_medical:client:playerRevived', patient.PlayerData.source) -- trigger me if item is removed
    else
        exports.qbx_core:Notify(player.PlayerData.source, locale('error.no_firstaid'), 'error')
    end
end)
```

for event `hospital:server:TreatWounds` it now also should only trigger the event if the bandage was removed like intended.
## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
