### PR TITLE
fix: secure hospital server events

### DIFF
--- a/client/hospital.lua
+++ b/client/hospital.lua
@@ -71,9 +71,6 @@ local function putPlayerInBed(hospitalName, bedIndex, isRevive, skipOpenCheck)
             CanLeaveBed = true
         end
     end)
-    if isRevive then
-        TriggerServerEvent('qbx_ambulancejob:server:playerEnteredBed', hospitalName, bedIndex)
-    end
 end
 
 RegisterNetEvent('qbx_ambulancejob:client:putPlayerInBed', function(hospitalName, bedIndex)

--- a/client/job.lua
+++ b/client/job.lua
@@ -6,6 +6,7 @@ local WEAPONS = exports.qbx_core:GetWeapons()
 ---@param data { vehicleName: string, coords: vector4}
 local function takeOutVehicle(data)
     local netId = lib.callback.await('qbx_ambulancejob:server:spawnVehicle', false, data.vehicleName, data.coords)
+    if not netId then return end
 
     local veh = lib.waitFor(function()
         if NetworkDoesEntityExistWithNetworkId(netId) then
@@ -85,6 +86,7 @@ RegisterNetEvent('hospital:client:CheckStatus', function()
     local playerId = GetPlayerServerId(player)
 
     local status = lib.callback.await('qbx_ambulancejob:server:getPlayerStatus', false, playerId)
+    if not status then return end
     if #status.injuries == 0 then
         exports.qbx_core:Notify(locale('success.healthy_player'), 'success')
         return

--- a/server/hospital.lua
+++ b/server/hospital.lua
@@ -3,11 +3,14 @@
 ---@class Player object from core
 
 local config = require 'config.server'
+local clientConfig = require 'config.client'
 local sharedConfig = require 'config.shared'
 local triggerEventHooks = require '@qbx_core.modules.hooks'
 local doctorCalled = false
+local spawnedVehicles = {}
+local vehiclesSpawning = {}
 
----@type table<string, table<number, boolean>>
+---@type table<string, table<number, boolean | number>>
 local hospitalBedsTaken = {}
 
 for hospitalName, hospital in pairs(sharedConfig.locations.hospitals) do
@@ -17,8 +20,61 @@ for hospitalName, hospital in pairs(sharedConfig.locations.hospitals) do
 	end
 end
 
+local function getHospitalBed(hospitalName, bedIndex)
+	if type(hospitalName) ~= 'string' or type(bedIndex) ~= 'number' or bedIndex % 1 ~= 0 then return end
+
+	local hospital = sharedConfig.locations.hospitals[hospitalName]
+	local bed = hospital and hospital.beds[bedIndex]
+	if not bed then return end
+
+	return hospital, bed
+end
+
+local function isPlayerNearCoords(source, coords, distance)
+	local ped = GetPlayerPed(source)
+	if ped == 0 then return false end
+
+	return #(GetEntityCoords(ped) - vec3(coords.x, coords.y, coords.z)) <= distance
+end
+
+local function isPlayerNearCheckIn(source, hospital)
+	if not hospital.checkIn then return false end
+
+	if type(hospital.checkIn) ~= 'table' then
+		return isPlayerNearCoords(source, hospital.checkIn, 5.0)
+	end
+
+	for i = 1, #hospital.checkIn do
+		if isPlayerNearCoords(source, hospital.checkIn[i], 5.0) then return true end
+	end
+
+	return false
+end
+
+local function isPlayerInBed(source)
+	for hospitalName, beds in pairs(hospitalBedsTaken) do
+		for bedIndex = 1, #beds do
+			if beds[bedIndex] == source then return hospitalName, bedIndex end
+		end
+	end
+end
+
+local function clearPlayerBed(source)
+	local hospitalName, bedIndex = isPlayerInBed(source)
+	if hospitalName then hospitalBedsTaken[hospitalName][bedIndex] = false end
+end
+
+local function reserveBed(source, hospitalName, bedIndex)
+	if isPlayerInBed(source) or hospitalBedsTaken[hospitalName][bedIndex] then return false end
+
+	hospitalBedsTaken[hospitalName][bedIndex] = source
+	return true
+end
+
 local function getOpenBed(hospitalName)
 	local beds = hospitalBedsTaken[hospitalName]
+	if not beds then return end
+
 	for i = 1, #beds do
 		local isTaken = beds[i]
 		if not isTaken then return i end
@@ -32,30 +88,41 @@ end)
 ---@param src number
 local function billPlayer(src)
 	local player = exports.qbx_core:GetPlayer(src)
-	player.Functions.RemoveMoney('bank', sharedConfig.checkInCost, 'respawned-at-hospital')
+	if not player then return end
+
+	if not player.Functions.RemoveMoney('bank', sharedConfig.checkInCost, 'respawned-at-hospital') then return end
 	config.depositSociety('ambulance', sharedConfig.checkInCost)
 	TriggerClientEvent('hospital:client:SendBillEmail', src, sharedConfig.checkInCost)
 end
 
-RegisterNetEvent('qbx_ambulancejob:server:playerEnteredBed', function(hospitalName, bedIndex)
-	if GetInvokingResource() then return end
-	local src = source
-	billPlayer(src)
-	hospitalBedsTaken[hospitalName][bedIndex] = true
-end)
-
 RegisterNetEvent('qbx_ambulancejob:server:playerLeftBed', function(hospitalName, bedIndex)
 	if GetInvokingResource() then return end
+	local _, bed = getHospitalBed(hospitalName, bedIndex)
+	if not bed or hospitalBedsTaken[hospitalName][bedIndex] ~= source then return end
+
 	hospitalBedsTaken[hospitalName][bedIndex] = false
 end)
 
 ---@param playerId number
 RegisterNetEvent('hospital:server:putPlayerInBed', function(playerId, hospitalName, bedIndex)
 	if GetInvokingResource() then return end
+	if type(playerId) ~= 'number' then return end
+
+	local src = source
+	local player = exports.qbx_core:GetPlayer(src)
+	local patient = exports.qbx_core:GetPlayer(playerId)
+	local _, bed = getHospitalBed(hospitalName, bedIndex)
+	if not player or player.PlayerData.job.type ~= 'ems' or not player.PlayerData.job.onduty or not patient or not bed then return end
+	if not isPlayerNearCoords(src, bed.coords, 5.0) or not isPlayerNearCoords(playerId, bed.coords, 5.0) then return end
+	if not reserveBed(playerId, hospitalName, bedIndex) then return end
+
 	TriggerClientEvent('qbx_ambulancejob:client:putPlayerInBed', playerId, hospitalName, bedIndex)
 end)
 
 lib.callback.register('qbx_ambulancejob:server:isBedTaken', function(_, hospitalName, bedIndex)
+	local _, bed = getHospitalBed(hospitalName, bedIndex)
+	if not bed then return true end
+
 	return hospitalBedsTaken[hospitalName][bedIndex]
 end)
 
@@ -65,8 +132,49 @@ local function wipeInventory(src)
 	exports.qbx_core:Notify(src, locale('error.possessions_taken'), 'error')
 end
 
-lib.callback.register('qbx_ambulancejob:server:spawnVehicle', function(source, vehicleName, vehicleCoords)
-	local netId, veh = qbx.spawnVehicle({ spawnSource = vehicleCoords or source, model = vehicleName, warp = GetPlayerPed(source)})
+local function getAuthorizedVehicleSpawn(player, vehicleName)
+	local grade = player.PlayerData.job.grade.level
+	local ped = GetPlayerPed(player.PlayerData.source)
+	if ped == 0 then return end
+
+	local playerCoords = GetEntityCoords(ped)
+	local vehicleGroups = {
+		{ vehicles = clientConfig.authorizedVehicles[grade], locations = sharedConfig.locations.vehicle },
+		{ vehicles = clientConfig.authorizedHelicopters[grade], locations = sharedConfig.locations.helicopter }
+	}
+
+	for i = 1, #vehicleGroups do
+		local group = vehicleGroups[i]
+		if group.vehicles and group.vehicles[vehicleName] then
+			for j = 1, #group.locations do
+				local coords = group.locations[j]
+				if #(playerCoords - coords.xyz) <= 7.5 then return coords end
+			end
+		end
+	end
+end
+
+lib.callback.register('qbx_ambulancejob:server:spawnVehicle', function(source, vehicleName)
+	if type(vehicleName) ~= 'string' then return end
+
+	local player = exports.qbx_core:GetPlayer(source)
+	if not player or player.PlayerData.job.type ~= 'ems' or not player.PlayerData.job.onduty then return end
+
+	local existingVehicle = spawnedVehicles[source]
+	if vehiclesSpawning[source] or existingVehicle and DoesEntityExist(existingVehicle) then return end
+
+	local vehicleCoords = getAuthorizedVehicleSpawn(player, vehicleName)
+	if not vehicleCoords then return end
+
+	vehiclesSpawning[source] = true
+	local netId, veh = qbx.spawnVehicle({ spawnSource = vehicleCoords, model = vehicleName, warp = GetPlayerPed(source)})
+	vehiclesSpawning[source] = nil
+	if not netId or not veh or veh == 0 then return end
+	if not exports.qbx_core:GetPlayer(source) then
+		DeleteEntity(veh)
+		return
+	end
+	spawnedVehicles[source] = veh
 
 	local vehType = GetVehicleType(veh)
 	local platePrefix = (vehType == 'heli') and locale('info.heli_plate') or locale('info.amb_plate')
@@ -92,6 +200,9 @@ local function sendDoctorAlert()
 end
 
 local function canCheckIn(source, hospitalName)
+	local hospital = type(hospitalName) == 'string' and sharedConfig.locations.hospitals[hospitalName]
+	if not hospital or not isPlayerNearCheckIn(source, hospital) then return false end
+
 	local numDoctors = exports.qbx_core:GetDutyCountType('ems')
 	if numDoctors >= sharedConfig.minForCheckIn then
 		exports.qbx_core:Notify(source, locale('info.dr_alert'), 'inform')
@@ -111,6 +222,10 @@ lib.callback.register('qbx_ambulancejob:server:canCheckIn', canCheckIn)
 ---@param patientSrc number the player being checked in
 ---@param hospitalName string name of the hospital matching the config where player should be placed
 local function checkIn(src, patientSrc, hospitalName)
+	if type(patientSrc) ~= 'number' then return false end
+
+	local hospital = type(hospitalName) == 'string' and sharedConfig.locations.hospitals[hospitalName]
+	if not hospital or not exports.qbx_core:GetPlayer(patientSrc) then return false end
 	if src == patientSrc and not canCheckIn(patientSrc, hospitalName) then return false end
 
 	local bedIndex = getOpenBed(hospitalName)
@@ -118,12 +233,16 @@ local function checkIn(src, patientSrc, hospitalName)
 		exports.qbx_core:Notify(src, locale('error.beds_taken'), 'error')
 		return false
 	end
+	if not reserveBed(patientSrc, hospitalName, bedIndex) then return false end
 
+	billPlayer(patientSrc)
 	TriggerClientEvent('qbx_ambulancejob:client:checkedIn', patientSrc, hospitalName, bedIndex)
 	return true
 end
 
-lib.callback.register('qbx_ambulancejob:server:checkIn', checkIn)
+lib.callback.register('qbx_ambulancejob:server:checkIn', function(source, _, hospitalName)
+	return checkIn(source, source, hospitalName)
+end)
 
 exports('CheckIn', checkIn)
 
@@ -146,11 +265,14 @@ local function respawn(src)
 		end
 	end
 
+	clearPlayerBed(src)
 	local bedIndex = getOpenBed(closestHospital)
 	if not bedIndex then
 		exports.qbx_core:Notify(src, locale('error.beds_taken'), 'error')
 		return
 	end
+	if not reserveBed(src, closestHospital, bedIndex) then return end
+	billPlayer(src)
 	TriggerClientEvent('qbx_ambulancejob:client:checkedIn', src, closestHospital, bedIndex)
 
 	if config.wipeInvOnRespawn then
@@ -159,3 +281,12 @@ local function respawn(src)
 end
 
 AddEventHandler('qbx_medical:server:playerRespawned', respawn)
+
+AddEventHandler('playerDropped', function()
+	clearPlayerBed(source)
+
+	local vehicle = spawnedVehicles[source]
+	if vehicle and DoesEntityExist(vehicle) then DeleteEntity(vehicle) end
+	spawnedVehicles[source] = nil
+	vehiclesSpawning[source] = nil
+end)

--- a/server/main.lua
+++ b/server/main.lua
@@ -2,7 +2,23 @@ local sharedConfig = require 'config.shared'
 
 ---@alias source number
 
-lib.callback.register('qbx_ambulancejob:server:getPlayerStatus', function(_, targetSrc)
+local function arePlayersNearby(source, targetSource, maxDistance)
+	if type(source) ~= 'number' or type(targetSource) ~= 'number' then return false end
+
+	local sourcePed = GetPlayerPed(source)
+	local targetPed = GetPlayerPed(targetSource)
+	if sourcePed == 0 or targetPed == 0 then return false end
+
+	return #(GetEntityCoords(sourcePed) - GetEntityCoords(targetPed)) <= maxDistance
+end
+
+lib.callback.register('qbx_ambulancejob:server:getPlayerStatus', function(source, targetSrc)
+	if type(targetSrc) ~= 'number' then return end
+
+	local player = exports.qbx_core:GetPlayer(source)
+	local target = exports.qbx_core:GetPlayer(targetSrc)
+	if not player or player.PlayerData.job.type ~= 'ems' or not target or not arePlayersNearby(source, targetSrc, 3.0) then return end
+
 	return exports.qbx_medical:GetPlayerStatus(targetSrc)
 end)
 
@@ -51,10 +67,12 @@ end)
 ---@param playerId number
 RegisterNetEvent('hospital:server:TreatWounds', function(playerId)
 	if GetInvokingResource() then return end
+	if type(playerId) ~= 'number' then return end
+
 	local src = source
 	local player = exports.qbx_core:GetPlayer(src)
 	local patient = exports.qbx_core:GetPlayer(playerId)
-	if player.PlayerData.job.type ~= 'ems' or not patient then return end
+	if not player or player.PlayerData.job.type ~= 'ems' or not patient or not arePlayersNearby(src, playerId, 3.0) then return end
 
 	if exports.ox_inventory:RemoveItem(src, 'bandage', 1) then
         TriggerClientEvent('hospital:client:HealInjuries', patient.PlayerData.source, 'full')
@@ -66,9 +84,11 @@ end)
 ---@param playerId number
 RegisterNetEvent('hospital:server:RevivePlayer', function(playerId)
 	if GetInvokingResource() then return end
+	if type(playerId) ~= 'number' then return end
+
 	local player = exports.qbx_core:GetPlayer(source)
 	local patient = exports.qbx_core:GetPlayer(playerId)
-	if not patient then return end
+	if not player or not patient or not arePlayersNearby(source, playerId, 3.0) then return end
 
     if player.PlayerData.job.type ~= 'ems' then
         lib.logger(source, 'RevivePlayer', ('"%s" triggered event for "%s" bus was missing the required job'):format(player.PlayerData.citizenid, patient.PlayerData.citizenid or ''))
@@ -85,9 +105,13 @@ end)
 ---@param targetId number
 RegisterNetEvent('hospital:server:UseFirstAid', function(targetId)
 	if GetInvokingResource() then return end
+	if type(targetId) ~= 'number' then return end
+
 	local src = source
+	local player = exports.qbx_core:GetPlayer(src)
 	local target = exports.qbx_core:GetPlayer(targetId)
-	if not target then return end
+	if not player or not target or not arePlayersNearby(src, targetId, 3.0) then return end
+	if exports.ox_inventory:Search(src, 'count', 'firstaid') < 1 then return end
 
 	local canHelp = lib.callback.await('hospital:client:canHelp', targetId)
 	if not canHelp then


### PR DESCRIPTION
## What changed

- validate hospital and bed identifiers before indexing configured state
- reserve beds on the server and only let the occupying player release them
- restrict forced bed placement to nearby, on-duty EMS and a nearby patient
- make client check-in callbacks self-only while preserving the trusted server export
- require self check-in callers to be near a configured check-in point
- move billing and bed reservation into the authoritative check-in/respawn path
- only credit the ambulance society when the patient's payment succeeds
- restrict ambulance vehicle spawning by job, duty, grade, configured model, and configured depot proximity
- allow one tracked spawned job vehicle per player and clean it up on disconnect
- require proximity and EMS authorization for status, treatment, and revive operations
- require a first-aid item and target proximity before beginning first-aid help

## Why

The affected client-reachable events trusted player IDs, hospital/bed keys, vehicle models, and spawn coordinates. A modified client could force other players into arbitrary beds, manipulate bed availability, spawn arbitrary vehicles at arbitrary coordinates, query remote medical status, or perform treatment/revive actions remotely. Billing was also client-triggered, allowing bed-state manipulation and society deposits even when money removal failed.

These decisions are now made and validated on the server while retaining the existing client-facing event and callback names.

## Validation

- `git diff --check`
- direct Lua control-flow and syntax review (no Lua runtime/linter is installed locally)
- GitHub lint workflow will be monitored and every lint-report finding fixed